### PR TITLE
src: consider fallback for MAP_ANON

### DIFF
--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -154,7 +154,13 @@ SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
 #include "windows.h"
 #else
 /* Provides mmap function. */
+#include <sys/types.h>
 #include <sys/mman.h>
+#ifndef MAP_ANON
+#ifdef MAP_ANONYMOUS
+#define MAP_ANON MAP_ANONYMOUS
+#endif
+#endif
 /* For detecting the page size. */
 #include <unistd.h>
 


### PR DESCRIPTION
Some legacy UNIX systems (like Tru64, HP-UX and AIX) use MAP_ANONYMOUS
instead of MAP_ANON, so make sure they won't need to fallback to the
case where no anonymous mapping is available (like in IRIX)

it has been since standarized by the Austin Group[1], that either name
is valid and should be considered equivalent.

While at it, add the sys/types.h that is indicated as required by the
documentation for completeness (eventhough I hadn't seen it needed)

[1] http://austingroupbugs.net/view.php?id=850