### PR TITLE
Hjl/cet/master

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -199,6 +199,14 @@
 #if defined(__CET__)
 #define SLJIT_CONFIG_X86_CET 1
 #endif
+#if (defined SLJIT_CONFIG_X86_CET && SLJIT_CONFIG_X86_CET)
+#if defined(__GNUC__)
+#if !defined (__SHSTK__)
+#error "-mshstk is needed to compile with -fcf-protection"
+#endif
+#include <x86intrin.h>
+#endif
+#endif
 #endif
 
 /**********************************/

--- a/sljit_src/sljitNativeX86_64.c
+++ b/sljit_src/sljitNativeX86_64.c
@@ -364,6 +364,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_return(struct sljit_compiler *comp
 		POP_REG(reg_lmap[i]);
 	}
 
+	/* Adjust shadow stack if needed.  */
+	FAIL_IF(adjust_shadow_stack(compiler, 0));
+
 	inst = (sljit_u8*)ensure_buf(compiler, 1 + 1);
 	FAIL_IF(!inst);
 	INC_SIZE(1);

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -702,6 +702,10 @@ static SLJIT_INLINE sljit_s32 emit_sse2_store(struct sljit_compiler *compiler,
 static SLJIT_INLINE sljit_s32 emit_sse2_load(struct sljit_compiler *compiler,
 	sljit_s32 single, sljit_s32 dst, sljit_s32 src, sljit_sw srcw);
 
+static sljit_s32 emit_cmp_binary(struct sljit_compiler *compiler,
+	sljit_s32 src1, sljit_sw src1w,
+	sljit_s32 src2, sljit_sw src2w);
+
 static SLJIT_INLINE sljit_s32 emit_endbranch(struct sljit_compiler *compiler)
 {
 #if (defined SLJIT_CONFIG_X86_CET && SLJIT_CONFIG_X86_CET)
@@ -718,6 +722,129 @@ static SLJIT_INLINE sljit_s32 emit_endbranch(struct sljit_compiler *compiler)
 #else
 	*inst = 0xfa;
 #endif
+#else
+	(void)compiler;
+#endif
+	return SLJIT_SUCCESS;
+}
+
+static SLJIT_INLINE sljit_s32 emit_rdssp(struct sljit_compiler *compiler, sljit_s32 reg)
+{
+#if (defined SLJIT_CONFIG_X86_CET && SLJIT_CONFIG_X86_CET)
+	sljit_u8 *inst;
+	sljit_s32 size;
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	size = 5;
+#else
+	size = 4;
+#endif
+
+	inst = (sljit_u8*)ensure_buf(compiler, 1 + size);
+	FAIL_IF(!inst);
+	INC_SIZE(size);
+	*inst++ = 0xf3;
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	*inst++ = REX_W | (reg_map[reg] <= 7 ? 0 : REX_B);
+#endif
+	*inst++ = 0x0f;
+	*inst++ = 0x1e;
+	*inst = (0x3 << 6) | (0x1 << 3) | (reg_map[reg] & 0x7);
+#else
+	(void)compiler;
+#endif
+	return SLJIT_SUCCESS;
+}
+
+static SLJIT_INLINE sljit_s32 emit_incssp(struct sljit_compiler *compiler, sljit_s32 reg)
+{
+#if (defined SLJIT_CONFIG_X86_CET && SLJIT_CONFIG_X86_CET)
+	sljit_u8 *inst;
+	sljit_s32 size;
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	size = 5;
+#else
+	size = 4;
+#endif
+
+	inst = (sljit_u8*)ensure_buf(compiler, 1 + size);
+	FAIL_IF(!inst);
+	INC_SIZE(size);
+	*inst++ = 0xf3;
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	*inst++ = REX_W | (reg_map[reg] <= 7 ? 0 : REX_B);
+#endif
+	*inst++ = 0x0f;
+	*inst++ = 0xae;
+	*inst = (0x3 << 6) | (0x5 << 3) | (reg_map[reg] & 0x7);
+#else
+	(void)compiler;
+#endif
+	return SLJIT_SUCCESS;
+}
+
+static SLJIT_INLINE sljit_s32 adjust_shadow_stack(struct sljit_compiler *compiler, sljit_sw immsp)
+{
+#if (defined SLJIT_CONFIG_X86_CET && SLJIT_CONFIG_X86_CET)
+/* NB: We can't use ECX to unwind shadow stack since it may be used by
+   sljit_emit_call and sljit_emit_return in JIT code as shown in sljit
+   test:
+
+$ ./bin/sljit_test
+Pass -v to enable verbose, -s to disable this hint.
+
+test51 case 2 failed
+SLJIT tests: 1 (2%) tests are FAILED on x86 32bit (little endian + unaligned) ABI:fastcall (with fpu)
+
+ */
+#define SCRATCH_REG	TMP_REG1
+
+	/* Don't adjust shadow stack if it isn't enabled.  */
+	if (!_get_ssp())
+		return SLJIT_SUCCESS;
+
+	sljit_u8 *inst;
+
+	sljit_s32 size_before_rdssp_inst = compiler->size;
+
+	/* Generate "RDSSP SCRATCH_REG". */
+	FAIL_IF(emit_rdssp(compiler, SCRATCH_REG));
+
+	/* Load return address on shadow stack into SCRATCH_REG. */
+	EMIT_MOV(compiler, SCRATCH_REG, 0, SLJIT_MEM1(SCRATCH_REG), 0);
+
+	/* Compare return address on stack against SCRATCH_REG. */
+	FAIL_IF(emit_cmp_binary (compiler, SCRATCH_REG, 0,
+				 SLJIT_MEM1(SLJIT_SP), immsp));
+
+	/* Generate JZ to skip shadow stack ajdustment when shadow
+	   stack matches normal stack. */
+	inst = (sljit_u8*)ensure_buf(compiler, 1 + 2);
+	FAIL_IF(!inst);
+	INC_SIZE(2);
+	*inst++ = get_jump_code(SLJIT_EQUAL) - 0x10;
+	sljit_s32 size_jz_after_cmp_inst = compiler->size;
+	sljit_u8 *jz_after_cmp_inst = inst;
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	/* REX_W is not necessary. */
+	compiler->mode32 = 1;
+#endif
+	/* Load 1 into SCRATCH_REG. */
+	EMIT_MOV(compiler, SCRATCH_REG, 0, SLJIT_IMM, 1);
+
+	/* Generate "INCSSP SCRATCH_REG". */
+	FAIL_IF(emit_incssp(compiler, SCRATCH_REG));
+
+	/* Jump back to "RDSSP SCRATCH_REG" to check shadow stack again. */
+	inst = (sljit_u8*)ensure_buf(compiler, 1 + 2);
+	FAIL_IF(!inst);
+	INC_SIZE(2);
+	*inst++ = JMP_i8;
+	*inst = size_before_rdssp_inst - compiler->size;
+
+	*jz_after_cmp_inst = compiler->size - size_jz_after_cmp_inst;
 #else
 	(void)compiler;
 #endif


### PR DESCRIPTION
Intel Control-flow Enforcement Technology (CET):

https://software.intel.com/en-us/articles/intel-sdm

contains shadow stack (SHSTK) and indirect branch tracking (IBT).  When
SHSTK is enabled, return address on normal stack must match the one on
shadow stack.  When IBT is enabled, the indirect branch target must
start with ENDBR instruction.  When CET is enabled at the compile time
with "gcc -fcf-protection -mshstk", this patch updates sljit with:

1. Emit ENDBR32/ENDBR64 at function entry.  ENDBR32/ENDBR64 are NOPs on
non-CET machines.
2. Add SLJIT_ENDBR to sljit_emit_op0 to generate ENDBR32/ENDBR64 for x86
processors.
3. Before JIT return, if shadow stack is enabled, adjust shadow stack
so that the top of show stack matches the top of normal stack.  NB: It
is safe since shadow stack is read-only, you can only skip stack frame,
not jump to anywhere else.
4. Fix X86_32 emit_x86_instruction to properly encode (%ebp) so that
we can use TMP_REG1 as scratch register to unwind show stack in
sljit_emit_return.  NB: ECX is unusable since it isn't a scratch
register in sljit.

When indirect branch tracking (IBT) from Intel Control-flow Enforcement
Technology (CET) is enabled, all indirect branch targets must start with
ENDBR32/ENDBR64.  This patch calls sljit_emit_op0 (compiler, SLJIT_ENDBR)
to generate ENDBR32/ENDBR64 at indirect branch targets for x86 processors
in sljitTest.c and  regexJIT.c.

Tested with
```
$ CC="gcc -Wl,-z,cet-report=error -fcf-protection -mshstk" make
```
on x86-32 and x86-64 Linux CET machines.