### PR TITLE
VS2019 patches

### DIFF
--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -726,7 +726,7 @@ static SLJIT_INLINE sljit_s32 emit_endbranch(struct sljit_compiler *compiler)
 	*inst = 0xfa;
 #endif
 #else
-	(void)compiler;
+	SLJIT_UNUSED_ARG(compiler);
 #endif
 	return SLJIT_SUCCESS;
 }
@@ -754,7 +754,8 @@ static SLJIT_INLINE sljit_s32 emit_rdssp(struct sljit_compiler *compiler, sljit_
 	*inst++ = 0x1e;
 	*inst = (0x3 << 6) | (0x1 << 3) | (reg_map[reg] & 0x7);
 #else
-	(void)compiler;
+	SLJIT_UNUSED_ARG(compiler);
+	SLJIT_UNUSED_ARG(reg);
 #endif
 	return SLJIT_SUCCESS;
 }
@@ -782,7 +783,8 @@ static SLJIT_INLINE sljit_s32 emit_incssp(struct sljit_compiler *compiler, sljit
 	*inst++ = 0xae;
 	*inst = (0x3 << 6) | (0x5 << 3) | (reg_map[reg] & 0x7);
 #else
-	(void)compiler;
+	SLJIT_UNUSED_ARG(compiler);
+	SLJIT_UNUSED_ARG(reg);
 #endif
 	return SLJIT_SUCCESS;
 }
@@ -860,6 +862,10 @@ static SLJIT_INLINE sljit_s32 adjust_shadow_stack(struct sljit_compiler *compile
 	*jz_after_cmp_inst = compiler->size - size_jz_after_cmp_inst;
 #else /* SLJIT_CONFIG_X86_CET */
 	SLJIT_UNUSED_ARG(compiler);
+	SLJIT_UNUSED_ARG(src);
+	SLJIT_UNUSED_ARG(srcw);
+	SLJIT_UNUSED_ARG(base);
+	SLJIT_UNUSED_ARG(disp);
 #endif /* SLJIT_CONFIG_X86_CET */
 	return SLJIT_SUCCESS;
 }

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -5438,7 +5438,7 @@ static void test56(void)
 	sljit_emit_op2(compiler, SLJIT_ADD32 | SLJIT_SET_OVERFLOW, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, -(91 << 12));
 	sljit_emit_op_flags(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 11 * sizeof(sljit_sw), SLJIT_OVERFLOW32);
 
-	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_R0, 0, SLJIT_IMM, (sljit_sw)-0x80000000);
+	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_R0, 0, SLJIT_IMM, -0x7fffffff-1);
 	sljit_emit_op1(compiler, SLJIT_NEG32 | SLJIT_SET_OVERFLOW, SLJIT_R0, 0, SLJIT_R0, 0);
 	sljit_emit_op_flags(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 12 * sizeof(sljit_sw), SLJIT_OVERFLOW32);
 


### PR DESCRIPTION
1. Fix VS2019 compile error C4146.
2. Mark some unused arguments to suppress compile warnings.