### PR TITLE
Make SLJIT_API_FUNC_ATTRIBUTE configurable from the outside

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -297,6 +297,7 @@ extern "C" {
 /* Type of public API functions. */
 /*********************************/
 
+#ifndef SLJIT_API_FUNC_ATTRIBUTE 
 #if (defined SLJIT_CONFIG_STATIC && SLJIT_CONFIG_STATIC)
 /* Static ABI functions. For all-in-one programs. */
 
@@ -310,6 +311,7 @@ extern "C" {
 #else
 #define SLJIT_API_FUNC_ATTRIBUTE
 #endif /* (defined SLJIT_CONFIG_STATIC && SLJIT_CONFIG_STATIC) */
+#endif /* defined SLJIT_API_FUNC_ATTRIBUTE */
 
 /****************************/
 /* Instruction cache flush. */


### PR DESCRIPTION
Make SLJIT_API_FUNC_ATTRIBUTE configurable. This could be used to let e.g. PCRE export the sljit functions from it's dll. This is useful for applications who want to use PCRE2 *and* sljit independently. For this to happen, another small change must be done to PCRE.