### PR TITLE
arm: correctly validate memw in sljit_emit_[f]mem

### DIFF
--- a/sljit_src/sljitNativeARM_32.c
+++ b/sljit_src/sljitNativeARM_32.c
@@ -2633,11 +2633,11 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 	}
 	else {
 		if (is_type1_transfer) {
-			if (memw > 4095 && memw < -4095)
+			if (memw > 4095 || memw < -4095)
 				return SLJIT_ERR_UNSUPPORTED;
 		}
 		else {
-			if (memw > 255 && memw < -255)
+			if (memw > 255 || memw < -255)
 				return SLJIT_ERR_UNSUPPORTED;
 		}
 	}

--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -1878,7 +1878,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_mem(compiler, type, reg, mem, memw));
 
-	if ((mem & OFFS_REG_MASK) || (memw > 255 && memw < -256))
+	if ((mem & OFFS_REG_MASK) || (memw > 255 || memw < -256))
 		return SLJIT_ERR_UNSUPPORTED;
 
 	if (type & SLJIT_MEM_SUPP)
@@ -1928,7 +1928,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fmem(struct sljit_compiler *compil
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_fmem(compiler, type, freg, mem, memw));
 
-	if ((mem & OFFS_REG_MASK) || (memw > 255 && memw < -256))
+	if ((mem & OFFS_REG_MASK) || (memw > 255 || memw < -256))
 		return SLJIT_ERR_UNSUPPORTED;
 
 	if (type & SLJIT_MEM_SUPP)

--- a/sljit_src/sljitNativeARM_T2_32.c
+++ b/sljit_src/sljitNativeARM_T2_32.c
@@ -2274,7 +2274,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_mem(compiler, type, reg, mem, memw));
 
-	if ((mem & OFFS_REG_MASK) || (memw > 255 && memw < -255))
+	if ((mem & OFFS_REG_MASK) || (memw > 255 || memw < -255))
 		return SLJIT_ERR_UNSUPPORTED;
 
 	if (type & SLJIT_MEM_SUPP)

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -5956,6 +5956,12 @@ static void test60(void)
 	SLJIT_ASSERT(sljit_emit_mem(compiler, SLJIT_MOV_S8 | SLJIT_MEM_SUPP | SLJIT_MEM_PRE, SLJIT_R0, SLJIT_MEM2(SLJIT_R1, SLJIT_R2), 1) == SLJIT_ERR_UNSUPPORTED);
 	SLJIT_ASSERT(sljit_emit_mem(compiler, SLJIT_MOV_S8 | SLJIT_MEM_SUPP | SLJIT_MEM_POST, SLJIT_R0, SLJIT_MEM2(SLJIT_R1, SLJIT_R2), 1) == SLJIT_ERR_UNSUPPORTED);
 
+#if (defined SLJIT_CONFIG_ARM_THUMB2 && SLJIT_CONFIG_ARM_THUMB2) || (defined SLJIT_CONFIG_ARM_64 && SLJIT_CONFIG_ARM_64)
+	/* TODO: at least for ARM (both V5 and V7) the range below needs further fixing */
+	SLJIT_ASSERT(sljit_emit_mem(compiler, SLJIT_MOV | SLJIT_MEM_SUPP | SLJIT_MEM_PRE, SLJIT_R1, SLJIT_MEM1(SLJIT_R0), 256) == SLJIT_ERR_UNSUPPORTED);
+	SLJIT_ASSERT(sljit_emit_mem(compiler, SLJIT_MOV | SLJIT_MEM_SUPP | SLJIT_MEM_POST, SLJIT_R1, SLJIT_MEM1(SLJIT_R0), -257) == SLJIT_ERR_UNSUPPORTED);
+#endif
+
 	sljit_emit_return(compiler, SLJIT_UNUSED, 0, 0);
 
 	code.code = sljit_generate_code(compiler);
@@ -6104,6 +6110,12 @@ static void test61(void)
 
 	SLJIT_ASSERT(sljit_emit_fmem(compiler, SLJIT_MOV_F64 | SLJIT_MEM_SUPP | SLJIT_MEM_POST, SLJIT_FR0, SLJIT_MEM2(SLJIT_R1, SLJIT_R2), 0) == SLJIT_ERR_UNSUPPORTED);
 	SLJIT_ASSERT(sljit_emit_fmem(compiler, SLJIT_MOV_F32 | SLJIT_MEM_SUPP | SLJIT_MEM_STORE | SLJIT_MEM_POST, SLJIT_FR0, SLJIT_MEM2(SLJIT_R1, SLJIT_R2), 0) == SLJIT_ERR_UNSUPPORTED);
+
+#if (defined SLJIT_CONFIG_ARM_64 && SLJIT_CONFIG_ARM_64)
+	/* TODO: at least for ARM (both V5 and V7) the range below needs further fixing */
+	SLJIT_ASSERT(sljit_emit_fmem(compiler, SLJIT_MOV_F64 | SLJIT_MEM_SUPP | SLJIT_MEM_PRE, SLJIT_FR0, SLJIT_MEM1(SLJIT_R0), 256) == SLJIT_ERR_UNSUPPORTED);
+	SLJIT_ASSERT(sljit_emit_fmem(compiler, SLJIT_MOV_F64 | SLJIT_MEM_SUPP | SLJIT_MEM_POST, SLJIT_FR0, SLJIT_MEM1(SLJIT_R0), -257) == SLJIT_ERR_UNSUPPORTED);
+#endif
 
 	sljit_emit_return(compiler, SLJIT_UNUSED, 0, 0);
 


### PR DESCRIPTION
the use of indexing modes when loading/storing has a[1]
limited range that was being validated incorrectly.

correct the logic and make sure tests are added to prevent
regressions which will otherwise show in at least linux
aarch64 with a modern clang as shown by:

In file included from sljit_src/sljitLir.c:2107:
sljit_src/sljitNativeARM_64.c:1881:43: warning: overlapping comparisons always evaluate to false [-Wtautological-overlap-compare]
        if ((mem & OFFS_REG_MASK) || (memw > 255 && memw < -256))
                                      ~~~~~~~~~~~^~~~~~~~~~~~~~
sljit_src/sljitNativeARM_64.c:1931:43: warning: overlapping comparisons always evaluate to false [-Wtautological-overlap-compare]
        if ((mem & OFFS_REG_MASK) || (memw > 255 && memw < -256))
                                      ~~~~~~~~~~~^~~~~~~~~~~~~~

similar code from all other ARM architectures was similarly
corrected but will need further testing and likely modifications
as it is not up to spec.

[1] http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0283b/Cihjhidd.html