### PR TITLE
test: fix test57 not to use freed memory

### DIFF
--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -5479,6 +5479,8 @@ static void test57(void)
 	executable_code code;
 	struct sljit_compiler* compiler = sljit_create_compiler(NULL);
 	struct sljit_label* labels[5];
+	sljit_p addr[5];
+	int i;
 
 	if (verbose)
 		printf("Run test57\n");
@@ -5507,21 +5509,25 @@ static void test57(void)
 
 	code.code = sljit_generate_code(compiler);
 	CHECK(compiler);
+
+	for (i = 0; i < 5; i++)
+		addr[i] = sljit_get_label_addr(labels[i]);
+
 	sljit_free_compiler(compiler);
 
 	code.func0();
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_PREFETCH)) {
-		FAILED(sljit_get_label_addr(labels[0]) == sljit_get_label_addr(labels[1]), "test57 case 1 failed\n");
-		FAILED(sljit_get_label_addr(labels[1]) == sljit_get_label_addr(labels[2]), "test57 case 2 failed\n");
-		FAILED(sljit_get_label_addr(labels[2]) == sljit_get_label_addr(labels[3]), "test57 case 3 failed\n");
-		FAILED(sljit_get_label_addr(labels[3]) == sljit_get_label_addr(labels[4]), "test57 case 4 failed\n");
+		FAILED(addr[0] == addr[1], "test57 case 1 failed\n");
+		FAILED(addr[1] == addr[2], "test57 case 2 failed\n");
+		FAILED(addr[2] == addr[3], "test57 case 3 failed\n");
+		FAILED(addr[3] == addr[4], "test57 case 4 failed\n");
 	}
 	else {
-		FAILED(sljit_get_label_addr(labels[0]) != sljit_get_label_addr(labels[1]), "test57 case 1 failed\n");
-		FAILED(sljit_get_label_addr(labels[1]) != sljit_get_label_addr(labels[2]), "test57 case 2 failed\n");
-		FAILED(sljit_get_label_addr(labels[2]) != sljit_get_label_addr(labels[3]), "test57 case 3 failed\n");
-		FAILED(sljit_get_label_addr(labels[3]) != sljit_get_label_addr(labels[4]), "test57 case 4 failed\n");
+		FAILED(addr[0] != addr[1], "test57 case 1 failed\n");
+		FAILED(addr[1] != addr[2], "test57 case 2 failed\n");
+		FAILED(addr[2] != addr[3], "test57 case 3 failed\n");
+		FAILED(addr[3] != addr[4], "test57 case 4 failed\n");
 	}
 
 	sljit_free_code(code.code);


### PR DESCRIPTION
otherwise failing in SE systems (ex: OpenBSD and HardenedBSD)
as well as reported by asan as shown by:

==151==ERROR: AddressSanitizer: heap-use-after-free on address 0x6210000dd518 at pc 0x000000428e30 bp 0x7ffe3fb99060 sp 0x7ffe3fb99050
READ of size 8 at 0x6210000dd518 thread T0
    #0 0x428e2f in sljit_get_label_addr sljit_src/sljitLir.h:1384
    #1 0x428e2f in test57 test_src/sljitTest.c:5515
    #2 0x428e2f in sljit_test test_src/sljitTest.c:6652
    #3 0x7feb57130041 in __libc_start_main (/lib64/libc.so.6+0x27041)
    #4 0x4013cd in _start (/usr/src/bin/sljit_test+0x4013cd)

label addresses must be copied out for using as they will be
wiped out once the compiler is destroyed.