### PR TITLE
netbsd: cleanup alloc_chunk() in sljitProtExec for NetBSD >= 8

### DIFF
--- a/sljit_src/sljitProtExecAllocator.c
+++ b/sljit_src/sljitProtExecAllocator.c
@@ -220,28 +220,26 @@ static SLJIT_INLINE struct chunk_header* alloc_chunk(sljit_uw size)
 static SLJIT_INLINE struct chunk_header* alloc_chunk(sljit_uw size)
 {
 	struct chunk_header *retval;
-	void *maprx;
 
 	retval = (struct chunk_header *)mmap(NULL, size,
-			PROT_MPROTECT(PROT_EXEC|PROT_WRITE|PROT_READ),
-			MAP_ANON, -1, 0);
+			PROT_READ | PROT_WRITE | PROT_MPROTECT(PROT_EXEC),
+			MAP_ANON | MAP_SHARED, -1, 0);
 
 	if (retval == MAP_FAILED)
 		return NULL;
 
-	maprx = mremap(retval, size, NULL, size, MAP_REMAPDUP);
-	if (maprx == MAP_FAILED) {
+	retval->executable = mremap(retval, size, NULL, size, MAP_REMAPDUP);
+	if (retval->executable == MAP_FAILED) {
 		munmap((void *)retval, size);
 		return NULL;
 	}
 
-	if (mprotect(retval, size, PROT_READ | PROT_WRITE) == -1 ||
-		mprotect(maprx, size, PROT_READ | PROT_EXEC) == -1) {
-		munmap(maprx, size);
+	if (mprotect(retval->executable, size, PROT_READ | PROT_EXEC) == -1) {
+		munmap(retval->executable, size);
 		munmap((void *)retval, size);
 		return NULL;
 	}
-	retval->executable = maprx;
+
 	return retval;
 }
 #endif /* NetBSD >= 8 */


### PR DESCRIPTION
in line with the current semantics make the map SHARED so it could
be used (with the same limitations and risks) like the old function
after fork()

Fixes: 9a3d3998dcaf151f5c562f8dde457790fe0d167c