### PR TITLE
JIT support for arm64

### DIFF
--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -153,6 +153,8 @@ static SLJIT_INLINE sljit_s32 emit_imm64_const(struct sljit_compiler *compiler, 
 
 static SLJIT_INLINE void modify_imm64_const(sljit_ins* inst, sljit_uw new_imm)
 {
+	SLJIT_SCOPE_ENABLE_JIT_WRITE();
+	
 	sljit_s32 dst = inst[0] & 0x1f;
 	SLJIT_ASSERT((inst[0] & 0xffe00000) == MOVZ && (inst[1] & 0xffe00000) == (MOVK | (1 << 21)));
 	inst[0] = MOVZ | dst | ((new_imm & 0xffff) << 5);
@@ -253,8 +255,10 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_generate_code(struct sljit_compiler *compil
 	CHECK_PTR(check_sljit_generate_code(compiler));
 	reverse_buf(compiler);
 
+	SLJIT_SCOPE_ENABLE_JIT_WRITE();
 	code = (sljit_ins*)SLJIT_MALLOC_EXEC(compiler->size * sizeof(sljit_ins));
 	PTR_FAIL_WITH_EXEC_IF(code);
+
 	buf = compiler->buf;
 
 	code_ptr = code;

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -109,6 +109,8 @@ static void test_exec_allocator(void)
 
 	if (verbose)
 		printf("Run executable allocator test\n");
+    
+	SLJIT_SCOPE_ENABLE_JIT_WRITE();
 
 	MALLOC_EXEC(ptr1, 32);
 	MALLOC_EXEC(ptr2, 512);


### PR DESCRIPTION
This PR introduces JIT support for Si. It makes the following changes:

* Adds macros for `__APPLE__` && `__arm64__`, shamelessly lifted from https://github.com/Unity-Technologies/mono/commit/3f2278e081484e6616ee5892895f999610453ca9
    * These macros are no-ops for other platforms
    * These macros utilize `__attribute__(clean(<function>))` to restore the previous state
* Enables write scope in specific functions that must write to this memory, namely:
    * `sljit_malloc_exec`
    * `sljit_free_exec` and
    * `modify_imm64_const`

Update the `test_exec_allocator` tests to use the `SLJIT_SCOPE_ENABLE_JIT_WRITE` macro to enable write access, as these tests write to the allocated memory returned from the allocator.