### PR TITLE
Haiku/Illumos build fix :

### DIFF
--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -157,6 +157,10 @@ SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
 #include <sys/types.h>
 #include <sys/mman.h>
 
+#ifndef MADV_DOTNEED
+#define madvise posix_madvise
+#define MADV_DOTNEED POSIX_MADV_DOTNEED
+#endif
 #ifndef MAP_ANON
 #ifdef MAP_ANONYMOUS
 #define MAP_ANON MAP_ANONYMOUS


### PR DESCRIPTION
- Haiku does not have madvise call.
- Illumos depends on the flags passed whether access to the old API or the newer one without madivse availability.