### PR TITLE
build: reintroduce bin directory dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ EXAMPLE_TARGET = $(BINDIR)/func_call $(BINDIR)/first_program $(BINDIR)/branch $(
 
 SLJIT_HEADERS = $(SRCDIR)/sljitLir.h $(SRCDIR)/sljitConfig.h $(SRCDIR)/sljitConfigInternal.h
 
-SLJIT_LIR_FILES = $(SRCDIR)/sljitLir.c $(SRCDIR)/sljitExecAllocator.c $(SRCDIR)/sljitUtils.c \
+SLJIT_LIR_FILES = $(SRCDIR)/sljitLir.c $(SRCDIR)/sljitUtils.c \
+	$(SRCDIR)/sljitExecAllocator.c $(SRCDIR)/sljitProtExecAllocator.c \
 	$(SRCDIR)/sljitNativeARM_32.c $(SRCDIR)/sljitNativeARM_T2_32.c $(SRCDIR)/sljitNativeARM_64.c \
 	$(SRCDIR)/sljitNativeMIPS_common.c $(SRCDIR)/sljitNativeMIPS_32.c $(SRCDIR)/sljitNativeMIPS_64.c \
 	$(SRCDIR)/sljitNativePPC_common.c $(SRCDIR)/sljitNativePPC_32.c $(SRCDIR)/sljitNativePPC_64.c \
@@ -39,60 +40,60 @@ SLJIT_LIR_FILES = $(SRCDIR)/sljitLir.c $(SRCDIR)/sljitExecAllocator.c $(SRCDIR)/
 	$(SRCDIR)/sljitNativeTILEGX_64.c \
 	$(SRCDIR)/sljitNativeX86_common.c $(SRCDIR)/sljitNativeX86_32.c $(SRCDIR)/sljitNativeX86_64.c
 
-.PHONY: all examples
+.PHONY: all clean examples
 
 all: $(TARGET)
 
-$(BINDIR) :
-	mkdir $(BINDIR)
+clean:
+	-$(RM) $(BINDIR)/*.o $(BINDIR)/sljit_test $(BINDIR)/regex_test $(EXAMPLE_TARGET)
 
-$(BINDIR)/sljitLir.o : $(SLJIT_LIR_FILES) $(SLJIT_HEADERS)
+$(BINDIR)/.keep :
+	mkdir -p $(BINDIR)
+	@touch $@
+
+$(BINDIR)/sljitLir.o : $(BINDIR)/.keep $(SLJIT_LIR_FILES) $(SLJIT_HEADERS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $(SRCDIR)/sljitLir.c
 
-$(BINDIR)/sljitMain.o : $(TESTDIR)/sljitMain.c $(SLJIT_HEADERS)
+$(BINDIR)/sljitMain.o : $(TESTDIR)/sljitMain.c $(BINDIR)/.keep $(SLJIT_HEADERS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $(TESTDIR)/sljitMain.c
 
-$(BINDIR)/sljitTest.o : $(TESTDIR)/sljitTest.c $(SLJIT_HEADERS)
+$(BINDIR)/sljitTest.o : $(TESTDIR)/sljitTest.c $(BINDIR)/.keep $(SLJIT_HEADERS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $(TESTDIR)/sljitTest.c
 
-$(BINDIR)/regexMain.o : $(REGEXDIR)/regexMain.c $(SLJIT_HEADERS)
+$(BINDIR)/regexMain.o : $(REGEXDIR)/regexMain.c $(BINDIR)/.keep $(SLJIT_HEADERS)
 	$(CC) $(CPPFLAGS) $(REGEX_CFLAGS) -c -o $@ $(REGEXDIR)/regexMain.c
 
-$(BINDIR)/regexJIT.o : $(REGEXDIR)/regexJIT.c $(SLJIT_HEADERS) $(REGEXDIR)/regexJIT.h
+$(BINDIR)/regexJIT.o : $(REGEXDIR)/regexJIT.c $(BINDIR)/.keep $(SLJIT_HEADERS) $(REGEXDIR)/regexJIT.h
 	$(CC) $(CPPFLAGS) $(REGEX_CFLAGS) -c -o $@ $(REGEXDIR)/regexJIT.c
 
-clean:
-	-$(RM) -f $(BINDIR)/*.o $(BINDIR)/sljit_test $(BINDIR)/regex_test $(EXAMPLE_TARGET)
-
-$(BINDIR)/sljit_test: $(BINDIR)/sljitMain.o $(BINDIR)/sljitTest.o $(BINDIR)/sljitLir.o
+$(BINDIR)/sljit_test: $(BINDIR)/.keep $(BINDIR)/sljitMain.o $(BINDIR)/sljitTest.o $(BINDIR)/sljitLir.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $(BINDIR)/sljitMain.o $(BINDIR)/sljitTest.o $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/regex_test: $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o
+$(BINDIR)/regex_test: $(BINDIR)/.keep $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
-
 
 examples: $(EXAMPLE_TARGET)
 
-$(BINDIR)/first_program: $(EXAMPLEDIR)/first_program.c $(BINDIR)/sljitLir.o
+$(BINDIR)/first_program: $(EXAMPLEDIR)/first_program.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/first_program.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/branch: $(EXAMPLEDIR)/branch.c $(BINDIR)/sljitLir.o
+$(BINDIR)/branch: $(EXAMPLEDIR)/branch.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/branch.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/loop: $(EXAMPLEDIR)/loop.c $(BINDIR)/sljitLir.o
+$(BINDIR)/loop: $(EXAMPLEDIR)/loop.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/loop.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/array_access: $(EXAMPLEDIR)/array_access.c $(BINDIR)/sljitLir.o
+$(BINDIR)/array_access: $(EXAMPLEDIR)/array_access.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/array_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/func_call: $(EXAMPLEDIR)/func_call.c $(BINDIR)/sljitLir.o
+$(BINDIR)/func_call: $(EXAMPLEDIR)/func_call.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/func_call.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/struct_access: $(EXAMPLEDIR)/struct_access.c $(BINDIR)/sljitLir.o
+$(BINDIR)/struct_access: $(EXAMPLEDIR)/struct_access.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/struct_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/temp_var: $(EXAMPLEDIR)/temp_var.c $(BINDIR)/sljitLir.o
+$(BINDIR)/temp_var: $(EXAMPLEDIR)/temp_var.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/temp_var.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread
 
-$(BINDIR)/brainfuck: $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/sljitLir.o
+$(BINDIR)/brainfuck: $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
 	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread


### PR DESCRIPTION
after the bin directory was removed as a dependency to cleanup (and fix)
the dependency tracking, the following scenario is possibly breaking
builds:

  $ git clean -fxd
  Removing bin/
  $ make
  cc  -DSLJIT_CONFIG_AUTO=1 -Isljit_src -O2 -Wall -c -o bin/sljitMain.o test_src/sljitMain.c
  error: unable to open output file 'bin/sljitMain.o': 'No such file or directory'
  1 error generated.
  make: *** [bin/sljitMain.o] Error 1

luckily I already fixed this problem in my "makefile" branch as
carenas/sljit@5618ec91b85df8427f38e36f850e1f828501aed4 so
implement it now by adding a sentinel to the bin directory and using
that instead as a dependency.

while at it, fix some other minor issues from that branch that are
hopefully something that we could agree on and might had even been
discussed recently.

CC: @nymacro
Fixes: fcf394a54711946ff938c084d8123e4af9940db2