### PR TITLE
wxexec: better support for SE systems including NetBSD

### DIFF
--- a/sljit_src/sljitWXExecAllocator.c
+++ b/sljit_src/sljitWXExecAllocator.c
@@ -58,12 +58,23 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 
+#ifdef __NetBSD__
+#if defined(PROT_MPROTECT)
+#define SLJIT_PROT_WX PROT_MPROTECT(PROT_EXEC)
+#endif /* PROT_MPROTECT */
+#endif /* NetBSD */
+
+#ifndef SLJIT_PROT_WX
+#define SLJIT_PROT_WX 0
+#endif /* !SLJIT_PROT_WX */
+
 SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 {
 	sljit_uw* ptr;
 
 	size += sizeof(sljit_uw);
-	ptr = (sljit_uw*)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+	ptr = (sljit_uw*)mmap(NULL, size, PROT_READ | PROT_WRITE | SLJIT_PROT_WX,
+				MAP_PRIVATE | MAP_ANON, -1, 0);
 
 	if (ptr == MAP_FAILED) {
 		return NULL;
@@ -72,6 +83,8 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 	*ptr++ = size;
 	return ptr;
 }
+
+#undef SLJIT_PROT_WX
 
 SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void* ptr)
 {


### PR DESCRIPTION
Adds all missing parts to wxexec so it will be supported in NetBSD userspace (with or without MPROTECT) and could be used as a foundation for the macOS Big Sur work

Fixes: #56 