### PR TITLE
util: consolidate all allocators to use get_page_alignment()

### DIFF
--- a/sljit_src/sljitExecAllocator.c
+++ b/sljit_src/sljitExecAllocator.c
@@ -104,17 +104,23 @@ static SLJIT_INLINE void free_chunk(void *chunk, sljit_uw size)
 
 #ifdef MAP_JIT
 
+/*
+   On macOS systems, returns MAP_JIT if it is defined _and_ we're running on a
+   version where it's OK to have more than one JIT block.
+   On non-macOS systems, returns MAP_JIT if it is defined.
+*/
 static SLJIT_INLINE int get_map_jit_flag()
 {
-/* On macOS systems, returns MAP_JIT if it is defined _and_ we're running on a version
-   of macOS where it's OK to have more than one JIT block.
-   On non-macOS systems, returns MAP_JIT if it is defined. */
 #if TARGET_OS_OSX
+	sljit_sw page_size = get_page_alignment() + 1;
+	void *ptr;
 	static int map_jit_flag = -1;
 
-	/* The following code is thread safe because multiple initialization
-	   sets map_jit_flag to the same value and the code has no side-effects.
-	   Changing the kernel version witout system restart is (very) unlikely. */
+	/*
+	  The following code is thread safe because multiple initialization
+	  sets map_jit_flag to the same value and the code has no side-effects.
+	  Changing the kernel version witout system restart is (very) unlikely.
+	*/
 	if (map_jit_flag == -1) {
 		struct utsname name;
 
@@ -123,15 +129,9 @@ static SLJIT_INLINE int get_map_jit_flag()
 
 		/* Kernel version for 10.14.0 (Mojave) */
 		if (atoi(name.release) >= 18) {
-			/* Only use MAP_JIT if a hardened runtime is used, because MAP_JIT is incompatible with fork(). */
+			/* Only use MAP_JIT if a hardened runtime is used */
 
-			/* mirroring page size detection from sljit_allocate_stack */
-			long page_size = sysconf(_SC_PAGESIZE);
-			/* Should never happen */
-			if (page_size < 0)
-				page_size = 4096;
-
-			void *ptr = mmap(NULL, page_size, PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, -1, 0);
+			ptr = mmap(NULL, page_size, PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, -1, 0);
 
 			if (ptr == MAP_FAILED) {
 				map_jit_flag = MAP_JIT;

--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -163,9 +163,6 @@ SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
 #endif /* MAP_ANONYMOUS */
 #endif /* !MAP_ANON */
 
-/* For detecting the page size. */
-#include <unistd.h>
-
 #ifndef MAP_ANON
 
 #include <fcntl.h>
@@ -207,6 +204,41 @@ static SLJIT_INLINE sljit_s32 open_dev_zero(void)
 #endif /* SLJIT_UTIL_STACK || SLJIT_EXECUTABLE_ALLOCATOR */
 
 #endif /* SLJIT_EXECUTABLE_ALLOCATOR || SLJIT_UTIL_GLOBAL_LOCK */
+
+#if (defined SLJIT_UTIL_STACK && SLJIT_UTIL_STACK) \
+	|| (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
+
+#ifdef _WIN32
+
+static SLJIT_INLINE sljit_sw get_page_alignment(void) {
+	SYSTEM_INFO si;
+	static sljit_sw sljit_page_align;
+	if (!sljit_page_align) {
+		GetSystemInfo(&si);
+		sljit_page_align = si.dwPageSize - 1;
+	}
+	return sljit_page_align;
+}
+
+#else
+
+#include <unistd.h>
+
+static SLJIT_INLINE sljit_sw get_page_alignment(void) {
+	static sljit_sw sljit_page_align;
+	if (!sljit_page_align) {
+		sljit_page_align = sysconf(_SC_PAGESIZE);
+		/* Should never happen. */
+		if (sljit_page_align < 0)
+			sljit_page_align = 4096;
+		sljit_page_align--;
+	}
+	return sljit_page_align;
+}
+
+#endif /* _WIN32 */
+
+#endif /* get_page_alignment() */
 
 #if (defined SLJIT_UTIL_STACK && SLJIT_UTIL_STACK)
 
@@ -258,16 +290,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_u8 *SLJIT_FUNC sljit_stack_resize(struct sljit_st
 
 #ifdef _WIN32
 
-SLJIT_INLINE static sljit_sw get_page_alignment(void) {
-	SYSTEM_INFO si;
-	static sljit_sw sljit_page_align;
-	if (!sljit_page_align) {
-		GetSystemInfo(&si);
-		sljit_page_align = si.dwPageSize - 1;
-	}
-	return sljit_page_align;
-}
-
 SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_free_stack(struct sljit_stack *stack, void *allocator_data)
 {
 	SLJIT_UNUSED_ARG(allocator_data);
@@ -276,18 +298,6 @@ SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_free_stack(struct sljit_stack *st
 }
 
 #else /* ! defined _WIN32 */
-
-SLJIT_INLINE static sljit_sw get_page_alignment(void) {
-	static sljit_sw sljit_page_align;
-	if (!sljit_page_align) {
-		sljit_page_align = sysconf(_SC_PAGESIZE);
-		/* Should never happen. */
-		if (sljit_page_align < 0)
-			sljit_page_align = 4096;
-		sljit_page_align--;
-	}
-	return sljit_page_align;
-}
 
 SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_free_stack(struct sljit_stack *stack, void *allocator_data)
 {

--- a/sljit_src/sljitWXExecAllocator.c
+++ b/sljit_src/sljitWXExecAllocator.c
@@ -41,7 +41,6 @@
 */
 
 #include <sys/mman.h>
-#include <unistd.h>
 
 SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 {
@@ -69,18 +68,13 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void* ptr)
 
 static void sljit_update_wx_flags(void *from, void *to, sljit_s32 enable_exec)
 {
-	static sljit_uw page_mask = 0;
+	sljit_uw page_mask = (sljit_uw)get_page_alignment();
 
 	sljit_uw start = (sljit_uw)from;
 	sljit_uw end = (sljit_uw)to;
 	int prot = PROT_READ | (enable_exec ? PROT_EXEC : PROT_WRITE);
 
 	SLJIT_ASSERT (start < end);
-
-	if (page_mask == 0) {
-		/* This is thread safe, since the value is constant. */
-		page_mask = (sljit_uw)(sysconf(_SC_PAGESIZE) - 1);
-	}
 
 	start &= ~page_mask;
 	end = (end + page_mask) & ~page_mask;


### PR DESCRIPTION
while at it, cleanup the comments and avoid mixed declarations with code
or unnecessary use of non sljit types in the original code.