### PR TITLE
util: fix race for initialization of executable allocator lock in windows

### DIFF
--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -28,7 +28,6 @@
 
 #ifdef _WIN32
 
-/* For SLJIT_CACHE_FLUSH, which can expand to FlushInstructionCache. */
 #include <windows.h>
 
 #endif /* _WIN32 */


### PR DESCRIPTION
fixes the known race condition for the initialization of the executable allocator lock in windows (which also affects the unused global lock, which has been left intentionally untouched)

Fixes: PCRE BUG2377[1]

[1] https://bugs.exim.org/show_bug.cgi?id=2377