### PR TITLE
util: avoid breaking API with sljit_{grab,release}_lock functions

### DIFF
--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -71,7 +71,19 @@ static pthread_mutex_t allocator_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #if (defined SLJIT_UTIL_GLOBAL_LOCK && SLJIT_UTIL_GLOBAL_LOCK)
 
-#if !(defined SLJIT_SINGLE_THREADED && SLJIT_SINGLE_THREADED)
+#if (defined SLJIT_SINGLE_THREADED && SLJIT_SINGLE_THREADED)
+
+SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void)
+{
+       /* Always successful. */
+}
+
+SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
+{
+       /* Always successful. */
+}
+
+#else
 
 #ifdef _WIN32
 


### PR DESCRIPTION
a careless refactoring broke the API by removing the global lock
functions completely if building without threads.

add the interfaces back for !!SLJIT_SINGLE_THREADED and avoid
doing more refactoring (for now)

Fixes: d1d893c97742cc3e84500a23f8d142c94680ba57