### PR TITLE
util: retire global lock

### DIFF
--- a/sljit_src/sljitConfig.h
+++ b/sljit_src/sljitConfig.h
@@ -63,10 +63,10 @@ extern "C" {
 /*  Utilities                                                            */
 /* --------------------------------------------------------------------- */
 
-/* Useful for thread-safe compiling of global functions. */
+/* Implement a global lock for last resort thread-safety. */
 #ifndef SLJIT_UTIL_GLOBAL_LOCK
-/* Enabled by default */
-#define SLJIT_UTIL_GLOBAL_LOCK 1
+/* Disabled by default */
+#define SLJIT_UTIL_GLOBAL_LOCK 0
 #endif
 
 /* Implements a stack like data structure (by using mmap / VirtualAlloc  */

--- a/sljit_src/sljitConfig.h
+++ b/sljit_src/sljitConfig.h
@@ -63,12 +63,6 @@ extern "C" {
 /*  Utilities                                                            */
 /* --------------------------------------------------------------------- */
 
-/* Implement a global lock for last resort thread-safety. */
-#ifndef SLJIT_UTIL_GLOBAL_LOCK
-/* Disabled by default */
-#define SLJIT_UTIL_GLOBAL_LOCK 0
-#endif
-
 /* Implements a stack like data structure (by using mmap / VirtualAlloc  */
 /* or a custom allocator). */
 #ifndef SLJIT_UTIL_STACK

--- a/sljit_src/sljitLir.h
+++ b/sljit_src/sljitLir.h
@@ -1406,7 +1406,9 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void);
 #define SLJIT_OFFSETOF(base, member) ((sljit_sw)(&((base*)0x10)->member) - 0x10)
 
 #if (defined SLJIT_UTIL_GLOBAL_LOCK && SLJIT_UTIL_GLOBAL_LOCK)
-/* This global lock is useful to compile common functions. */
+/* This interface is not safe, overly broad and therefore not very
+   useful, and likely not used so it is planned to be removed in
+   the next release. */
 SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void);
 SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void);
 #endif

--- a/sljit_src/sljitLir.h
+++ b/sljit_src/sljitLir.h
@@ -1405,14 +1405,6 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void);
 /* Portable helper function to get an offset of a member. */
 #define SLJIT_OFFSETOF(base, member) ((sljit_sw)(&((base*)0x10)->member) - 0x10)
 
-#if (defined SLJIT_UTIL_GLOBAL_LOCK && SLJIT_UTIL_GLOBAL_LOCK)
-/* This interface is not safe, overly broad and therefore not very
-   useful, and likely not used so it is planned to be removed in
-   the next release. */
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void);
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void);
-#endif
-
 #if (defined SLJIT_UTIL_STACK && SLJIT_UTIL_STACK)
 
 /* The sljit_stack structure and its manipulation functions provides

--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -61,64 +61,6 @@ static SLJIT_INLINE void allocator_grab_lock(void)
 #endif /* thread implementation */
 #endif /* SLJIT_EXECUTABLE_ALLOCATOR && !SLJIT_WX_EXECUTABLE_ALLOCATOR */
 
-/* Global */
-
-#if (defined SLJIT_UTIL_GLOBAL_LOCK && SLJIT_UTIL_GLOBAL_LOCK)
-
-#if (defined SLJIT_SINGLE_THREADED && SLJIT_SINGLE_THREADED)
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void)
-{
-       /* Always successful. */
-}
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
-{
-       /* Always successful. */
-}
-
-#else
-
-#ifdef _WIN32
-
-static HANDLE global_mutex = 0;
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void)
-{
-	/* No idea what to do if an error occures. Static mutexes should never fail... */
-	if (!global_mutex)
-		global_mutex = CreateMutex(NULL, TRUE, NULL);
-	else
-		WaitForSingleObject(global_mutex, INFINITE);
-}
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
-{
-	ReleaseMutex(global_mutex);
-}
-
-#else /* !_WIN32 */
-
-#include <pthread.h>
-
-static pthread_mutex_t global_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_grab_lock(void)
-{
-	pthread_mutex_lock(&global_mutex);
-}
-
-SLJIT_API_FUNC_ATTRIBUTE void SLJIT_FUNC sljit_release_lock(void)
-{
-	pthread_mutex_unlock(&global_mutex);
-}
-
-#endif /* _WIN32 */
-
-#endif /* SLJIT_SINGLE_THREADED */
-
-#endif /* SLJIT_UTIL_GLOBAL_LOCK */
-
 /* ------------------------------------------------------------------------ */
 /*  Stack                                                                   */
 /* ------------------------------------------------------------------------ */

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -133,11 +133,6 @@ static void test_exec_allocator(void)
 	FREE_EXEC(ptr3);
 	FREE_EXEC(ptr1);
 	FREE_EXEC(ptr2);
-#if (defined SLJIT_UTIL_GLOBAL_LOCK && SLJIT_UTIL_GLOBAL_LOCK)
-	/* Just call the global locks. */
-	sljit_grab_lock();
-	sljit_release_lock();
-#endif
 
 #if (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
 	sljit_free_unused_memory_exec();


### PR DESCRIPTION
split into 2 phases to allow for a staged release for anyone that might care about ABI compatibility, but considering it is buggy and most likely not used it might as well be done in one fell swoop