### PR TITLE
test: run tests in multiple threads to check for races or other similar issues

### DIFF
--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -57,7 +57,7 @@ union executable_code {
 };
 typedef union executable_code executable_code;
 
-static sljit_s32 successful_tests = 0;
+static sljit_u32 successful_tests = 0;
 static sljit_s32 verbose = 0;
 static sljit_s32 silent = 0;
 
@@ -6675,13 +6675,14 @@ int sljit_test(int argc, char* argv[])
 	sljit_free_unused_memory_exec();
 #endif
 
-#	define TEST_COUNT 68
+#	define TEST_COUNT 68u
+#endif
 
 	printf("SLJIT tests: ");
 	if (successful_tests == TEST_COUNT)
-		printf("all tests are " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
+		printf("all %u tests " COLOR_GREEN "PASSED" COLOR_DEFAULT " ", TEST_COUNT);
 	else
-		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests are " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / TEST_COUNT);
+		printf(COLOR_RED "%u" COLOR_DEFAULT " (" COLOR_RED "%u%%" COLOR_DEFAULT ") tests " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / TEST_COUNT);
 	printf("on " COLOR_ARCH "%s" COLOR_DEFAULT "%s\n", sljit_get_platform_name(), sljit_has_cpu_feature(SLJIT_HAS_FPU) ? " (with fpu)" : " (without fpu)");
 
 	return TEST_COUNT - successful_tests;

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -27,25 +27,35 @@
 /* Must be the first one. Must not depend on any other include. */
 #include "sljitLir.h"
 
+#ifndef _WIN32
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4127) /* conditional expression is constant */
-#endif
+#define SLJIT_TEST_FUNC void *
+#define SLJIT_TEST_RETURN(r) return (void *)r
 
-#if defined _WIN32 || defined _WIN64
-#define COLOR_RED
-#define COLOR_GREEN
-#define COLOR_ARCH
-#define COLOR_DEFAULT
-#else
 #define COLOR_RED "\33[31m"
 #define COLOR_GREEN "\33[32m"
 #define COLOR_ARCH "\33[33m"
 #define COLOR_DEFAULT "\33[0m"
+#else
+#include <windows.h>
+
+#define SLJIT_TEST_FUNC DWORD WINAPI
+#define SLJIT_TEST_RETURN(r) return r
+
+#define COLOR_RED
+#define COLOR_GREEN
+#define COLOR_ARCH
+#define COLOR_DEFAULT
+#endif /* !windows */
+#define SLJIT_TEST(f) successful_tests += (sljit_u32)f
+#define SLJIT_TEST_SUCCEEDED() SLJIT_TEST_RETURN(1)
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) /* conditional expression is constant */
 #endif
 
 union executable_code {
@@ -61,18 +71,22 @@ static sljit_u32 successful_tests = 0;
 static sljit_s32 verbose = 0;
 static sljit_s32 silent = 0;
 
-#define FAILED(cond, text) \
-	if (SLJIT_UNLIKELY(cond)) { \
-		printf(text); \
-		return; \
-	}
+#define SLJIT_TEST_FAILED(cond, text) \
+	do { \
+		if (SLJIT_UNLIKELY(cond)) { \
+			printf(text); \
+			SLJIT_TEST_RETURN(0); \
+		} \
+	} while(0)
 
 #define CHECK(compiler) \
-	if (sljit_get_compiler_error(compiler) != SLJIT_ERR_COMPILED) { \
-		printf("Compiler error: %d\n", sljit_get_compiler_error(compiler)); \
-		sljit_free_compiler(compiler); \
-		return; \
-	}
+	do { \
+		if (sljit_get_compiler_error(compiler) != SLJIT_ERR_COMPILED) { \
+			printf("Compiler error: %d\n", sljit_get_compiler_error(compiler)); \
+			sljit_free_compiler(compiler); \
+			SLJIT_TEST_RETURN(0); \
+		} \
+	} while(0)
 
 static void cond_set(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw, sljit_s32 type)
 {
@@ -93,14 +107,14 @@ static void cond_set(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw ds
 	result = SLJIT_MALLOC_EXEC(size); \
 	if (!result) { \
 		printf("Cannot allocate executable memory\n"); \
-		return; \
+		return 0; \
 	} \
 	memset(result, 255, size);
 
 #define FREE_EXEC(ptr) \
 	SLJIT_FREE_EXEC(((sljit_u8*)(ptr)) + SLJIT_EXEC_OFFSET(ptr));
 
-static void test_exec_allocator(void)
+static SLJIT_TEST_FUNC test_exec_allocator(void *p)
 {
 	/* This is not an sljit test. */
 	void *ptr1;
@@ -142,13 +156,14 @@ static void test_exec_allocator(void)
 #if (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
 	sljit_free_unused_memory_exec();
 #endif
+	SLJIT_TEST_SUCCEEDED();
 }
 
 #undef MALLOC_EXEC
 
 #endif /* !(defined SLJIT_CONFIG_UNSUPPORTED && SLJIT_CONFIG_UNSUPPORTED) */
 
-static void test1(void)
+static SLJIT_TEST_FUNC test1(void *p)
 {
 	/* Enter and return from an sljit function. */
 	executable_code code;
@@ -157,7 +172,7 @@ static void test1(void)
 	if (verbose)
 		printf("Run test1\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	/* 3 arguments passed, 3 arguments used. */
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), 3, 3, 0, 0, 0);
@@ -170,14 +185,14 @@ static void test1(void)
 	SLJIT_ASSERT(sljit_get_generated_code_size(compiler) > 0);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func3(3, -21, 86) != -21, "test1 case 1 failed\n");
-	FAILED(code.func3(4789, 47890, 997) != 47890, "test1 case 2 failed\n");
+	SLJIT_TEST_FAILED(code.func3(3, -21, 86) != -21, "test1 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func3(4789, 47890, 997) != 47890, "test1 case 2 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test2(void)
+static SLJIT_TEST_FUNC test2(void *p)
 {
 	/* Test mov. */
 	executable_code code;
@@ -188,7 +203,7 @@ static void test2(void)
 	if (verbose)
 		printf("Run test2\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = 5678;
 	buf[1] = 0;
@@ -225,20 +240,20 @@ static void test2(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 9999, "test2 case 1 failed\n");
-	FAILED(buf[1] != 9999, "test2 case 2 failed\n");
-	FAILED(buf[2] != 9999, "test2 case 3 failed\n");
-	FAILED(buf[3] != 5678, "test2 case 4 failed\n");
-	FAILED(buf[4] != -9876, "test2 case 5 failed\n");
-	FAILED(buf[5] != 5678, "test2 case 6 failed\n");
-	FAILED(buf[6] != 3456, "test2 case 6 failed\n");
-	FAILED(buf[7] != 3456, "test2 case 6 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 9999, "test2 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 9999, "test2 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 9999, "test2 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 5678, "test2 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != -9876, "test2 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 5678, "test2 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 3456, "test2 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 3456, "test2 case 6 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test3(void)
+static SLJIT_TEST_FUNC test3(void *p)
 {
 	/* Test not. */
 	executable_code code;
@@ -248,7 +263,7 @@ static void test3(void)
 	if (verbose)
 		printf("Run test3\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 1234;
 	buf[1] = 0;
 	buf[2] = 9876;
@@ -269,16 +284,16 @@ static void test3(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != ~1234, "test3 case 1 failed\n");
-	FAILED(buf[1] != ~1234, "test3 case 2 failed\n");
-	FAILED(buf[3] != ~9876, "test3 case 3 failed\n");
-	FAILED(buf[4] != ~0x12345678, "test3 case 4 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != ~1234, "test3 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != ~1234, "test3 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != ~9876, "test3 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != ~0x12345678, "test3 case 4 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test4(void)
+static SLJIT_TEST_FUNC test4(void *p)
 {
 	/* Test neg. */
 	executable_code code;
@@ -288,7 +303,7 @@ static void test4(void)
 	if (verbose)
 		printf("Run test4\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 1234;
 	buf[2] = 0;
@@ -306,16 +321,16 @@ static void test4(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func2((sljit_sw)&buf, 4567) != -4567, "test4 case 1 failed\n");
-	FAILED(buf[0] != -1234, "test4 case 2 failed\n");
-	FAILED(buf[2] != -4567, "test4 case 3 failed\n");
-	FAILED(buf[3] != -299, "test4 case 4 failed\n");
+	SLJIT_TEST_FAILED(code.func2((sljit_sw)&buf, 4567) != -4567, "test4 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -1234, "test4 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -4567, "test4 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != -299, "test4 case 4 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test5(void)
+static SLJIT_TEST_FUNC test5(void *p)
 {
 	/* Test add. */
 	executable_code code;
@@ -325,7 +340,7 @@ static void test5(void)
 	if (verbose)
 		printf("Run test5\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 100;
 	buf[1] = 200;
 	buf[2] = 300;
@@ -365,21 +380,21 @@ static void test5(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 2437 + 2 * sizeof(sljit_sw), "test5 case 1 failed\n");
-	FAILED(buf[0] != 202 + 2 * sizeof(sljit_sw), "test5 case 2 failed\n");
-	FAILED(buf[2] != 500, "test5 case 3 failed\n");
-	FAILED(buf[3] != 400, "test5 case 4 failed\n");
-	FAILED(buf[4] != 200, "test5 case 5 failed\n");
-	FAILED(buf[5] != 250, "test5 case 6 failed\n");
-	FAILED(buf[6] != 0x425bb5f8, "test5 case 7 failed\n");
-	FAILED(buf[7] != 0x5bf01e44, "test5 case 8 failed\n");
-	FAILED(buf[8] != 270, "test5 case 9 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 2437 + 2 * sizeof(sljit_sw), "test5 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 202 + 2 * sizeof(sljit_sw), "test5 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 500, "test5 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 400, "test5 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 200, "test5 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 250, "test5 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0x425bb5f8, "test5 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 0x5bf01e44, "test5 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 270, "test5 case 9 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test6(void)
+static SLJIT_TEST_FUNC test6(void *p)
 {
 	/* Test addc, sub, subc. */
 	executable_code code;
@@ -389,7 +404,7 @@ static void test6(void)
 	if (verbose)
 		printf("Run test6\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -443,24 +458,24 @@ static void test6(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 2223, "test6 case 1 failed\n");
-	FAILED(buf[0] != 1, "test6 case 2 failed\n");
-	FAILED(buf[1] != 5, "test6 case 3 failed\n");
-	FAILED(buf[2] != 50, "test6 case 4 failed\n");
-	FAILED(buf[3] != 4, "test6 case 5 failed\n");
-	FAILED(buf[4] != 50, "test6 case 6 failed\n");
-	FAILED(buf[5] != 50, "test6 case 7 failed\n");
-	FAILED(buf[6] != 1000, "test6 case 8 failed\n");
-	FAILED(buf[7] != 100 - 32768, "test6 case 9 failed\n");
-	FAILED(buf[8] != 100 + 32767, "test6 case 10 failed\n");
-	FAILED(buf[9] != 0x152aa42e, "test6 case 11 failed\n");
-	FAILED(buf[10] != -2000, "test6 case 12 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 2223, "test6 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 1, "test6 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 5, "test6 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 50, "test6 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 4, "test6 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 50, "test6 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 50, "test6 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 1000, "test6 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 100 - 32768, "test6 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 100 + 32767, "test6 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 0x152aa42e, "test6 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != -2000, "test6 case 12 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test7(void)
+static SLJIT_TEST_FUNC test7(void *p)
 {
 	/* Test logical operators. */
 	executable_code code;
@@ -470,7 +485,7 @@ static void test7(void)
 	if (verbose)
 		printf("Run test7\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0xff80;
 	buf[1] = 0x0f808080;
 	buf[2] = 0;
@@ -505,21 +520,21 @@ static void test7(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 0x8808, "test7 case 1 failed\n");
-	FAILED(buf[0] != 0x0F807F00, "test7 case 2 failed\n");
-	FAILED(buf[1] != 0x0F7F7F7F, "test7 case 3 failed\n");
-	FAILED(buf[2] != 0x00F0F08F, "test7 case 4 failed\n");
-	FAILED(buf[3] != 0x00A0A0A0, "test7 case 5 failed\n");
-	FAILED(buf[4] != 0x00FF80B0, "test7 case 6 failed\n");
-	FAILED(buf[5] != 0x00FF4040, "test7 case 7 failed\n");
-	FAILED(buf[6] != 0xa56c82c0, "test7 case 8 failed\n");
-	FAILED(buf[7] != 0x3b3a8095, "test7 case 9 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 0x8808, "test7 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0x0F807F00, "test7 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0x0F7F7F7F, "test7 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0x00F0F08F, "test7 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0x00A0A0A0, "test7 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 0x00FF80B0, "test7 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0x00FF4040, "test7 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0xa56c82c0, "test7 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 0x3b3a8095, "test7 case 9 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test8(void)
+static SLJIT_TEST_FUNC test8(void *p)
 {
 	/* Test flags (neg, cmp, test). */
 	executable_code code;
@@ -529,7 +544,7 @@ static void test8(void)
 	if (verbose)
 		printf("Run test8\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 100;
 	buf[1] = 3;
 	buf[2] = 3;
@@ -592,24 +607,24 @@ static void test8(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[1] != 1, "test8 case 1 failed\n");
-	FAILED(buf[2] != 0, "test8 case 2 failed\n");
-	FAILED(buf[3] != 0, "test8 case 3 failed\n");
-	FAILED(buf[4] != 1, "test8 case 4 failed\n");
-	FAILED(buf[5] != 1, "test8 case 5 failed\n");
-	FAILED(buf[6] != 1, "test8 case 6 failed\n");
-	FAILED(buf[7] != 1, "test8 case 7 failed\n");
-	FAILED(buf[8] != 0, "test8 case 8 failed\n");
-	FAILED(buf[9] != 1, "test8 case 9 failed\n");
-	FAILED(buf[10] != 0, "test8 case 10 failed\n");
-	FAILED(buf[11] != 1, "test8 case 11 failed\n");
-	FAILED(buf[12] != 0, "test8 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 1, "test8 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0, "test8 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0, "test8 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 1, "test8 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 1, "test8 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 1, "test8 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test8 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 0, "test8 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 1, "test8 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 0, "test8 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 1, "test8 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 0, "test8 case 12 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test9(void)
+static SLJIT_TEST_FUNC test9(void *p)
 {
 	/* Test shift. */
 	executable_code code;
@@ -626,7 +641,7 @@ static void test9(void)
 	if (verbose)
 		printf("Run test9\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -723,25 +738,25 @@ static void test9(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 0x3c, "test9 case 1 failed\n");
-	FAILED(buf[1] != 0xf0, "test9 case 2 failed\n");
-	FAILED(buf[2] != -16, "test9 case 3 failed\n");
-	FAILED(buf[3] != 0xff0, "test9 case 4 failed\n");
-	FAILED(buf[4] != 4, "test9 case 5 failed\n");
-	FAILED(buf[5] != 0xff00, "test9 case 6 failed\n");
-	FAILED(buf[6] != 0x3c, "test9 case 7 failed\n");
-	FAILED(buf[7] != 0xf0, "test9 case 8 failed\n");
-	FAILED(buf[8] != 0xf0, "test9 case 9 failed\n");
-	FAILED(buf[9] != 0x18, "test9 case 10 failed\n");
-	FAILED(buf[10] != 32, "test9 case 11 failed\n");
-	FAILED(buf[11] != 0x4ae37da9, "test9 case 12 failed\n");
-	FAILED(buf[12] != 0x63f65c, "test9 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0x3c, "test9 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0xf0, "test9 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -16, "test9 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0xff0, "test9 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 4, "test9 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0xff00, "test9 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0x3c, "test9 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 0xf0, "test9 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 0xf0, "test9 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 0x18, "test9 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 32, "test9 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 0x4ae37da9, "test9 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 0x63f65c, "test9 case 13 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test10(void)
+static SLJIT_TEST_FUNC test10(void *p)
 {
 	/* Test multiplications. */
 	executable_code code;
@@ -751,7 +766,7 @@ static void test10(void)
 	if (verbose)
 		printf("Run test10\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 3;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -789,22 +804,22 @@ static void test10(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 110, "test10 case 1 failed\n");
-	FAILED(buf[0] != 15, "test10 case 2 failed\n");
-	FAILED(buf[1] != 56, "test10 case 3 failed\n");
-	FAILED(buf[2] != 12, "test10 case 4 failed\n");
-	FAILED(buf[3] != -12, "test10 case 5 failed\n");
-	FAILED(buf[4] != 100, "test10 case 6 failed\n");
-	FAILED(buf[5] != 81, "test10 case 7 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 110, "test10 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 15, "test10 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 56, "test10 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 12, "test10 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != -12, "test10 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 100, "test10 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 81, "test10 case 7 failed\n");
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[6] != SLJIT_W(0x123456789) * 3, "test10 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != SLJIT_W(0x123456789) * 3, "test10 case 8 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test11(void)
+static SLJIT_TEST_FUNC test11(void *p)
 {
 	/* Test rewritable constants. */
 	executable_code code;
@@ -831,7 +846,7 @@ static void test11(void)
 	if (verbose)
 		printf("Run test11\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -875,26 +890,26 @@ static void test11(void)
 	const4_addr = sljit_get_const_addr(const4);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 0xf7afcdb7, "test11 case 1 failed\n");
-	FAILED(buf[0] != -0x81b9, "test11 case 2 failed\n");
-	FAILED(buf[1] != -65535, "test11 case 3 failed\n");
-	FAILED(buf[2] != word_value1, "test11 case 4 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 0xf7afcdb7, "test11 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -0x81b9, "test11 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -65535, "test11 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != word_value1, "test11 case 4 failed\n");
 
 	sljit_set_const(const1_addr, -1, executable_offset);
 	sljit_set_const(const2_addr, word_value2, executable_offset);
 	sljit_set_const(const3_addr, 0xbab0fea1, executable_offset);
 	sljit_set_const(const4_addr, -60089, executable_offset);
 
-	FAILED(code.func1((sljit_sw)&buf) != -60089, "test11 case 5 failed\n");
-	FAILED(buf[0] != -1, "test11 case 6 failed\n");
-	FAILED(buf[1] != word_value2, "test11 case 7 failed\n");
-	FAILED(buf[2] != 0xbab0fea1, "test11 case 8 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != -60089, "test11 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -1, "test11 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != word_value2, "test11 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0xbab0fea1, "test11 case 8 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test12(void)
+static SLJIT_TEST_FUNC test12(void *p)
 {
 	/* Test rewriteable jumps. */
 	executable_code code;
@@ -915,7 +930,7 @@ static void test12(void)
 	if (verbose)
 		printf("Run test12\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 3, 2, 0, 0, 0);
@@ -966,24 +981,24 @@ static void test12(void)
 	sljit_free_compiler(compiler);
 
 	code.func2((sljit_sw)&buf, 4);
-	FAILED(buf[0] != 5, "test12 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 5, "test12 case 1 failed\n");
 
 	code.func2((sljit_sw)&buf, 11);
-	FAILED(buf[0] != 6, "test12 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 6, "test12 case 2 failed\n");
 
 	sljit_set_jump_addr(jump1_addr, label2_addr, executable_offset);
 	code.func2((sljit_sw)&buf, 12);
-	FAILED(buf[0] != 7, "test12 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 7, "test12 case 3 failed\n");
 
 	sljit_set_jump_addr(jump1_addr, label1_addr, executable_offset);
 	code.func2((sljit_sw)&buf, 13);
-	FAILED(buf[0] != 6, "test12 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 6, "test12 case 4 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test13(void)
+static SLJIT_TEST_FUNC test13(void *p)
 {
 	/* Test fpu monadic functions. */
 	executable_code code;
@@ -997,13 +1012,12 @@ static void test13(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test13 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 7.75;
 	buf[1] = -4.5;
 	buf[2] = 0.0;
@@ -1054,24 +1068,24 @@ static void test13(void)
 	sljit_free_compiler(compiler);
 
 	code.func2((sljit_sw)&buf, (sljit_sw)&buf2);
-	FAILED(buf[2] != -4.5, "test13 case 1 failed\n");
-	FAILED(buf[3] != 4.5, "test13 case 2 failed\n");
-	FAILED(buf[4] != -7.75, "test13 case 3 failed\n");
-	FAILED(buf[5] != 4.5, "test13 case 4 failed\n");
-	FAILED(buf[6] != -4.5, "test13 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -4.5, "test13 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 4.5, "test13 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != -7.75, "test13 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 4.5, "test13 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != -4.5, "test13 case 5 failed\n");
 
-	FAILED(buf2[0] != 1, "test13 case 6 failed\n");
-	FAILED(buf2[1] != 0, "test13 case 7 failed\n");
-	FAILED(buf2[2] != 1, "test13 case 8 failed\n");
-	FAILED(buf2[3] != 0, "test13 case 9 failed\n");
-	FAILED(buf2[4] != 0, "test13 case 10 failed\n");
-	FAILED(buf2[5] != 1, "test13 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf2[0] != 1, "test13 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf2[1] != 0, "test13 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf2[2] != 1, "test13 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf2[3] != 0, "test13 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf2[4] != 0, "test13 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf2[5] != 1, "test13 case 11 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test14(void)
+static SLJIT_TEST_FUNC test14(void *p)
 {
 	/* Test fpu diadic functions. */
 	executable_code code;
@@ -1084,10 +1098,9 @@ static void test14(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test14 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 	buf[0] = 7.25;
 	buf[1] = 3.5;
@@ -1105,7 +1118,7 @@ static void test14(void)
 	buf[13] = 4.0;
 	buf[14] = 0.0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 3, 1, 6, 0, 0);
 
 	/* ADD */
@@ -1153,21 +1166,21 @@ static void test14(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[3] != 10.75, "test14 case 1 failed\n");
-	FAILED(buf[4] != 5.25, "test14 case 2 failed\n");
-	FAILED(buf[5] != 7.0, "test14 case 3 failed\n");
-	FAILED(buf[6] != 0.0, "test14 case 4 failed\n");
-	FAILED(buf[7] != 5.5, "test14 case 5 failed\n");
-	FAILED(buf[8] != 3.75, "test14 case 6 failed\n");
-	FAILED(buf[9] != 24.5, "test14 case 7 failed\n");
-	FAILED(buf[10] != 38.5, "test14 case 8 failed\n");
-	FAILED(buf[11] != 9.625, "test14 case 9 failed\n");
-	FAILED(buf[12] != 2.0, "test14 case 10 failed\n");
-	FAILED(buf[13] != 2.0, "test14 case 11 failed\n");
-	FAILED(buf[14] != 0.5, "test14 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 10.75, "test14 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 5.25, "test14 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 7.0, "test14 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0.0, "test14 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 5.5, "test14 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 3.75, "test14 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 24.5, "test14 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 38.5, "test14 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 9.625, "test14 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 2.0, "test14 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != 2.0, "test14 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != 0.5, "test14 case 12 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
 static sljit_sw SLJIT_FUNC func(sljit_sw a, sljit_sw b, sljit_sw c)
@@ -1175,7 +1188,7 @@ static sljit_sw SLJIT_FUNC func(sljit_sw a, sljit_sw b, sljit_sw c)
 	return a + b + c + 5;
 }
 
-static void test15(void)
+static SLJIT_TEST_FUNC test15(void *p)
 {
 	/* Test function call. */
 	executable_code code;
@@ -1186,7 +1199,7 @@ static void test15(void)
 	if (verbose)
 		printf("Run test15\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -1248,20 +1261,20 @@ static void test15(void)
 	sljit_set_jump_addr(sljit_get_jump_addr(jump), SLJIT_FUNC_OFFSET(func), sljit_get_executable_offset(compiler));
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != -15, "test15 case 1 failed\n");
-	FAILED(buf[0] != 14, "test15 case 2 failed\n");
-	FAILED(buf[1] != -8, "test15 case 3 failed\n");
-	FAILED(buf[2] != SLJIT_FUNC_OFFSET(func) + 42, "test15 case 4 failed\n");
-	FAILED(buf[3] != SLJIT_FUNC_OFFSET(func) - 85, "test15 case 5 failed\n");
-	FAILED(buf[4] != SLJIT_FUNC_OFFSET(func) + 31, "test15 case 6 failed\n");
-	FAILED(buf[5] != 335, "test15 case 7 failed\n");
-	FAILED(buf[6] != -15, "test15 case 8 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != -15, "test15 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 14, "test15 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -8, "test15 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != SLJIT_FUNC_OFFSET(func) + 42, "test15 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != SLJIT_FUNC_OFFSET(func) - 85, "test15 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != SLJIT_FUNC_OFFSET(func) + 31, "test15 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 335, "test15 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != -15, "test15 case 8 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test16(void)
+static SLJIT_TEST_FUNC test16(void *p)
 {
 	/* Ackermann benchmark. */
 	executable_code code;
@@ -1275,7 +1288,7 @@ static void test16(void)
 	if (verbose)
 		printf("Run test16\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	entry = sljit_emit_label(compiler);
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 3, 2, 0, 0, 0);
@@ -1318,15 +1331,15 @@ static void test16(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func2(3, 3) != 61, "test16 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func2(3, 3) != 61, "test16 case 1 failed\n");
 	/* For benchmarking. */
-	/* FAILED(code.func2(3, 11) != 16381, "test16 case 1 failed\n"); */
+	/* SLJIT_TEST_FAILED(code.func2(3, 11) != 16381, "test16 case 1 failed\n"); */
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test17(void)
+static SLJIT_TEST_FUNC test17(void *p)
 {
 	/* Test arm constant pool. */
 	executable_code code;
@@ -1337,7 +1350,7 @@ static void test17(void)
 	if (verbose)
 		printf("Run test17\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -1359,17 +1372,17 @@ static void test17(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED((sljit_uw)buf[0] != 0x81818000, "test17 case 1 failed\n");
-	FAILED((sljit_uw)buf[1] != 0x81818400, "test17 case 2 failed\n");
-	FAILED((sljit_uw)buf[2] != 0x81818800, "test17 case 3 failed\n");
-	FAILED((sljit_uw)buf[3] != 0x81818c00, "test17 case 4 failed\n");
-	FAILED((sljit_uw)buf[4] != 0x81818fff, "test17 case 5 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[0] != 0x81818000, "test17 case 1 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[1] != 0x81818400, "test17 case 2 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[2] != 0x81818800, "test17 case 3 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[3] != 0x81818c00, "test17 case 4 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[4] != 0x81818fff, "test17 case 5 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test18(void)
+static SLJIT_TEST_FUNC test18(void *p)
 {
 	/* Test 64 bit. */
 	executable_code code;
@@ -1379,7 +1392,7 @@ static void test18(void)
 	if (verbose)
 		printf("Run test18\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -1444,40 +1457,40 @@ static void test18(void)
 
 	code.func1((sljit_sw)&buf);
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[0] != SLJIT_W(0x1122334455667788), "test18 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != SLJIT_W(0x1122334455667788), "test18 case 1 failed\n");
 #if (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
-	FAILED(buf[1] != 0x55667788, "test18 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0x55667788, "test18 case 2 failed\n");
 #else
-	FAILED(buf[1] != SLJIT_W(0x5566778800000000), "test18 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != SLJIT_W(0x5566778800000000), "test18 case 2 failed\n");
 #endif
-	FAILED(buf[2] != SLJIT_W(2000000000000), "test18 case 3 failed\n");
-	FAILED(buf[3] != SLJIT_W(4000000000000), "test18 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != SLJIT_W(2000000000000), "test18 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != SLJIT_W(4000000000000), "test18 case 4 failed\n");
 #if (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
-	FAILED(buf[4] != 0x28282828, "test18 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 0x28282828, "test18 case 5 failed\n");
 #else
-	FAILED(buf[4] != SLJIT_W(0x2828282800000000), "test18 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != SLJIT_W(0x2828282800000000), "test18 case 5 failed\n");
 #endif
-	FAILED(buf[5] != 0, "test18 case 6 failed\n");
-	FAILED(buf[6] != 1, "test18 case 7 failed\n");
-	FAILED(buf[7] != 1, "test18 case 8 failed\n");
-	FAILED(buf[8] != 0, "test18 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0, "test18 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 1, "test18 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test18 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 0, "test18 case 9 failed\n");
 #if (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
-	FAILED(buf[9] != 0xfff00000, "test18 case 10 failed\n");
-	FAILED(buf[10] != 0xffffffff, "test18 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 0xfff00000, "test18 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 0xffffffff, "test18 case 11 failed\n");
 #else
-	FAILED(buf[9] != SLJIT_W(0xfff0000000000000), "test18 case 10 failed\n");
-	FAILED(buf[10] != SLJIT_W(0xffffffff00000000), "test18 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != SLJIT_W(0xfff0000000000000), "test18 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != SLJIT_W(0xffffffff00000000), "test18 case 11 failed\n");
 #endif
 #else
-	FAILED(buf[0] != 0x11223344, "test18 case 1 failed\n");
-	FAILED(buf[1] != 0x44332211, "test18 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0x11223344, "test18 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0x44332211, "test18 case 2 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test19(void)
+static SLJIT_TEST_FUNC test19(void *p)
 {
 	/* Test arm partial instruction caching. */
 	executable_code code;
@@ -1487,7 +1500,7 @@ static void test19(void)
 	if (verbose)
 		printf("Run test19\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 6;
 	buf[1] = 4;
 	buf[2] = 0;
@@ -1516,20 +1529,20 @@ static void test19(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 10, "test19 case 1 failed\n");
-	FAILED(buf[1] != 4, "test19 case 2 failed\n");
-	FAILED(buf[2] != 14, "test19 case 3 failed\n");
-	FAILED(buf[3] != 14, "test19 case 4 failed\n");
-	FAILED(buf[4] != 8, "test19 case 5 failed\n");
-	FAILED(buf[5] != 6, "test19 case 6 failed\n");
-	FAILED(buf[6] != 12, "test19 case 7 failed\n");
-	FAILED(buf[7] != 10, "test19 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 10, "test19 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 4, "test19 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 14, "test19 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 14, "test19 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 8, "test19 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 6, "test19 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 12, "test19 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 10, "test19 case 8 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test20(void)
+static SLJIT_TEST_FUNC test20(void *p)
 {
 	/* Test stack. */
 	executable_code code;
@@ -1546,7 +1559,7 @@ static void test20(void)
 	if (verbose)
 		printf("Run test20\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 5;
 	buf[1] = 12;
 	buf[2] = 0;
@@ -1576,11 +1589,11 @@ static void test20(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != -12345, "test20 case 1 failed\n")
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != -12345, "test20 case 1 failed\n");
 
-	FAILED(buf[2] != 60, "test20 case 2 failed\n");
-	FAILED(buf[3] != 17, "test20 case 3 failed\n");
-	FAILED(buf[4] != 7, "test20 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 60, "test20 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 17, "test20 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 7, "test20 case 4 failed\n");
 
 	sljit_free_code(code.code);
 
@@ -1606,7 +1619,7 @@ static void test20(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func3(1234, 5678, 9012) != 15924, "test20 case 5 failed\n");
+	SLJIT_TEST_FAILED(code.func3(1234, 5678, 9012) != 15924, "test20 case 5 failed\n");
 
 	sljit_free_code(code.code);
 
@@ -1630,13 +1643,13 @@ static void test20(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func0() % sizeof(sljit_f64) != 0, "test20 case 6 failed\n");
+	SLJIT_TEST_FAILED(code.func0() % sizeof(sljit_f64) != 0, "test20 case 6 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test21(void)
+static SLJIT_TEST_FUNC test21(void *p)
 {
 	/* Test set context. The parts of the jit code can be separated in the memory. */
 	executable_code code1;
@@ -1650,7 +1663,7 @@ static void test21(void)
 	if (verbose)
 		printf("Run test21\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 9;
 	buf[1] = -6;
 	buf[2] = 0;
@@ -1673,7 +1686,7 @@ static void test21(void)
 	sljit_free_compiler(compiler);
 
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	/* Other part of the jit code. */
 	sljit_set_context(compiler, 0, 1, 3, 2, 0, 0, 2 * sizeof(sljit_sw));
@@ -1691,16 +1704,16 @@ static void test21(void)
 
 	sljit_set_jump_addr(addr, SLJIT_FUNC_OFFSET(code2.code), executable_offset);
 
-	FAILED(code1.func1((sljit_sw)&buf) != 19, "test21 case 1 failed\n");
-	FAILED(buf[2] != -16, "test21 case 2 failed\n");
-	FAILED(buf[3] != 100, "test21 case 3 failed\n");
+	SLJIT_TEST_FAILED(code1.func1((sljit_sw)&buf) != 19, "test21 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -16, "test21 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 100, "test21 case 3 failed\n");
 
 	sljit_free_code(code1.code);
 	sljit_free_code(code2.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test22(void)
+static SLJIT_TEST_FUNC test22(void *p)
 {
 	/* Test simple byte and half-int data transfers. */
 	executable_code code;
@@ -1712,7 +1725,7 @@ static void test22(void)
 	if (verbose)
 		printf("Run test22\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 
@@ -1768,28 +1781,28 @@ static void test22(void)
 	sljit_free_compiler(compiler);
 
 	code.func3((sljit_sw)&buf, (sljit_sw)&sbuf, (sljit_sw)&bbuf);
-	FAILED(buf[0] != -9, "test22 case 1 failed\n");
-	FAILED(buf[1] != -56, "test22 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -9, "test22 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -56, "test22 case 2 failed\n");
 
-	FAILED(sbuf[0] != -13, "test22 case 3 failed\n");
-	FAILED(sbuf[1] != 0x1234, "test22 case 4 failed\n");
-	FAILED(sbuf[3] != 0x1234, "test22 case 5 failed\n");
-	FAILED(sbuf[4] != 8000, "test22 case 6 failed\n");
-	FAILED(sbuf[5] != -9317, "test22 case 7 failed\n");
-	FAILED(sbuf[6] != -9317, "test22 case 8 failed\n");
-	FAILED(sbuf[7] != -8888, "test22 case 9 failed\n");
-	FAILED(sbuf[8] != -8888, "test22 case 10 failed\n");
+	SLJIT_TEST_FAILED(sbuf[0] != -13, "test22 case 3 failed\n");
+	SLJIT_TEST_FAILED(sbuf[1] != 0x1234, "test22 case 4 failed\n");
+	SLJIT_TEST_FAILED(sbuf[3] != 0x1234, "test22 case 5 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != 8000, "test22 case 6 failed\n");
+	SLJIT_TEST_FAILED(sbuf[5] != -9317, "test22 case 7 failed\n");
+	SLJIT_TEST_FAILED(sbuf[6] != -9317, "test22 case 8 failed\n");
+	SLJIT_TEST_FAILED(sbuf[7] != -8888, "test22 case 9 failed\n");
+	SLJIT_TEST_FAILED(sbuf[8] != -8888, "test22 case 10 failed\n");
 
-	FAILED(bbuf[0] != -45, "test22 case 11 failed\n");
-	FAILED(bbuf[1] != 0x12, "test22 case 12 failed\n");
-	FAILED(bbuf[3] != -56, "test22 case 13 failed\n");
-	FAILED(bbuf[4] != 4, "test22 case 14 failed\n");
+	SLJIT_TEST_FAILED(bbuf[0] != -45, "test22 case 11 failed\n");
+	SLJIT_TEST_FAILED(bbuf[1] != 0x12, "test22 case 12 failed\n");
+	SLJIT_TEST_FAILED(bbuf[3] != -56, "test22 case 13 failed\n");
+	SLJIT_TEST_FAILED(bbuf[4] != 4, "test22 case 14 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test23(void)
+static SLJIT_TEST_FUNC test23(void *p)
 {
 	/* Test 32 bit / 64 bit signed / unsigned int transfer and conversion.
 	   This test has do real things on 64 bit systems, but works on 32 bit systems as well. */
@@ -1810,7 +1823,7 @@ static void test23(void)
 	if (verbose)
 		printf("Run test23\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -1869,37 +1882,37 @@ static void test23(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func2((sljit_sw)&buf, (sljit_sw)&ibuf) != -13, "test23 case 1 failed\n");
-	FAILED(buf[0] != -5791, "test23 case 2 failed\n");
-	FAILED(buf[1] != 43579, "test23 case 3 failed\n");
-	FAILED(buf[2] != 658923, "test23 case 4 failed\n");
-	FAILED(buf[3] != 0x0f00f00, "test23 case 5 failed\n");
-	FAILED(buf[4] != 0x0f00f00, "test23 case 6 failed\n");
-	FAILED(buf[5] != 80, "test23 case 7 failed\n");
-	FAILED(buf[6] != 0x123456, "test23 case 8 failed\n");
-	FAILED(buf[7] != (sljit_sw)&buf[5], "test23 case 9 failed\n");
-	FAILED(buf[8] != (sljit_sw)&buf[5] + 6, "test23 case 10 failed\n");
+	SLJIT_TEST_FAILED(code.func2((sljit_sw)&buf, (sljit_sw)&ibuf) != -13, "test23 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -5791, "test23 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 43579, "test23 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 658923, "test23 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0x0f00f00, "test23 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 0x0f00f00, "test23 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 80, "test23 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0x123456, "test23 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != (sljit_sw)&buf[5], "test23 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != (sljit_sw)&buf[5] + 6, "test23 case 10 failed\n");
 
-	FAILED(ibuf[0] != 34567, "test23 case 11 failed\n");
-	FAILED(ibuf[1] != -7654, "test23 case 12 failed\n");
+	SLJIT_TEST_FAILED(ibuf[0] != 34567, "test23 case 11 failed\n");
+	SLJIT_TEST_FAILED(ibuf[1] != -7654, "test23 case 12 failed\n");
 	u.asint = ibuf[4];
 #if (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
-	FAILED(u.asbytes[0] != 0x78, "test23 case 13 failed\n");
-	FAILED(u.asbytes[1] != 0x56, "test23 case 14 failed\n");
-	FAILED(u.asbytes[2] != 0x34, "test23 case 15 failed\n");
-	FAILED(u.asbytes[3] != 0x12, "test23 case 16 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[0] != 0x78, "test23 case 13 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[1] != 0x56, "test23 case 14 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[2] != 0x34, "test23 case 15 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[3] != 0x12, "test23 case 16 failed\n");
 #else
-	FAILED(u.asbytes[0] != 0x12, "test23 case 13 failed\n");
-	FAILED(u.asbytes[1] != 0x34, "test23 case 14 failed\n");
-	FAILED(u.asbytes[2] != 0x56, "test23 case 15 failed\n");
-	FAILED(u.asbytes[3] != 0x78, "test23 case 16 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[0] != 0x12, "test23 case 13 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[1] != 0x34, "test23 case 14 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[2] != 0x56, "test23 case 15 failed\n");
+	SLJIT_TEST_FAILED(u.asbytes[3] != 0x78, "test23 case 16 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test24(void)
+static SLJIT_TEST_FUNC test24(void *p)
 {
 	/* Some complicated addressing modes. */
 	executable_code code;
@@ -1911,7 +1924,7 @@ static void test24(void)
 	if (verbose)
 		printf("Run test24\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = 100567;
 	buf[1] = 75799;
@@ -1989,31 +2002,31 @@ static void test24(void)
 	sljit_free_compiler(compiler);
 
 	code.func3((sljit_sw)&buf, (sljit_sw)&sbuf, (sljit_sw)&bbuf);
-	FAILED(buf[2] != 176366, "test24 case 1 failed\n");
-	FAILED(buf[3] != 64, "test24 case 2 failed\n");
-	FAILED(buf[4] != -100, "test24 case 3 failed\n");
-	FAILED(buf[5] != 100567, "test24 case 4 failed\n");
-	FAILED(buf[6] != 952467, "test24 case 5 failed\n");
-	FAILED(buf[7] != 952467, "test24 case 6 failed\n");
-	FAILED(buf[8] != 952467 * 2, "test24 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 176366, "test24 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 64, "test24 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != -100, "test24 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 100567, "test24 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 952467, "test24 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 952467, "test24 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 952467 * 2, "test24 case 7 failed\n");
 
-	FAILED(sbuf[1] != 30000, "test24 case 8 failed\n");
-	FAILED(sbuf[2] != -12345, "test24 case 9 failed\n");
-	FAILED(sbuf[4] != sizeof(sljit_s16), "test24 case 10 failed\n");
+	SLJIT_TEST_FAILED(sbuf[1] != 30000, "test24 case 8 failed\n");
+	SLJIT_TEST_FAILED(sbuf[2] != -12345, "test24 case 9 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != sizeof(sljit_s16), "test24 case 10 failed\n");
 
-	FAILED(bbuf[1] != -128, "test24 case 11 failed\n");
-	FAILED(bbuf[2] != 99, "test24 case 12 failed\n");
-	FAILED(bbuf[4] != 99, "test24 case 13 failed\n");
-	FAILED(bbuf[5] != 99, "test24 case 14 failed\n");
+	SLJIT_TEST_FAILED(bbuf[1] != -128, "test24 case 11 failed\n");
+	SLJIT_TEST_FAILED(bbuf[2] != 99, "test24 case 12 failed\n");
+	SLJIT_TEST_FAILED(bbuf[4] != 99, "test24 case 13 failed\n");
+	SLJIT_TEST_FAILED(bbuf[5] != 99, "test24 case 14 failed\n");
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(bbuf[6] != -128, "test24 case 15 failed\n");
+	SLJIT_TEST_FAILED(bbuf[6] != -128, "test24 case 15 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test25(void)
+static SLJIT_TEST_FUNC test25(void *p)
 {
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
 	/* 64 bit loads. */
@@ -2024,7 +2037,7 @@ static void test25(void)
 	if (verbose)
 		printf("Run test25\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 7;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -2064,27 +2077,27 @@ static void test25(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 0, "test25 case 1 failed\n");
-	FAILED(buf[1] != 0x7fff, "test25 case 2 failed\n");
-	FAILED(buf[2] != -0x8000, "test25 case 3 failed\n");
-	FAILED(buf[3] != 0x7fffffff, "test25 case 4 failed\n");
-	FAILED(buf[4] != SLJIT_W(-0x80000000), "test25 case 5 failed\n");
-	FAILED(buf[5] != SLJIT_W(0x1234567887654321), "test25 case 6 failed\n");
-	FAILED(buf[6] != SLJIT_W(0xff80000000), "test25 case 7 failed\n");
-	FAILED(buf[7] != SLJIT_W(0x3ff0000000), "test25 case 8 failed\n");
-	FAILED((sljit_uw)buf[8] != SLJIT_W(0xfffffff800100000), "test25 case 9 failed\n");
-	FAILED((sljit_uw)buf[9] != SLJIT_W(0xfffffff80010f000), "test25 case 10 failed\n");
-	FAILED(buf[10] != SLJIT_W(0x07fff00000008001), "test25 case 11 failed\n");
-	FAILED(buf[11] != SLJIT_W(0x07fff00080010000), "test25 case 12 failed\n");
-	FAILED(buf[12] != SLJIT_W(0x07fff00080018001), "test25 case 13 failed\n");
-	FAILED(buf[13] != SLJIT_W(0x07fff00ffff00000), "test25 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0, "test25 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0x7fff, "test25 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -0x8000, "test25 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0x7fffffff, "test25 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != SLJIT_W(-0x80000000), "test25 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != SLJIT_W(0x1234567887654321), "test25 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != SLJIT_W(0xff80000000), "test25 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != SLJIT_W(0x3ff0000000), "test25 case 8 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[8] != SLJIT_W(0xfffffff800100000), "test25 case 9 failed\n");
+	SLJIT_TEST_FAILED((sljit_uw)buf[9] != SLJIT_W(0xfffffff80010f000), "test25 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != SLJIT_W(0x07fff00000008001), "test25 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != SLJIT_W(0x07fff00080010000), "test25 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != SLJIT_W(0x07fff00080018001), "test25 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != SLJIT_W(0x07fff00ffff00000), "test25 case 14 failed\n");
 
 	sljit_free_code(code.code);
 #endif
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test26(void)
+static SLJIT_TEST_FUNC test26(void *p)
 {
 	/* Aligned access without aligned offsets. */
 	executable_code code;
@@ -2096,7 +2109,7 @@ static void test26(void)
 	if (verbose)
 		printf("Run test26\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = -2789;
 	buf[1] = 0;
@@ -2145,22 +2158,22 @@ static void test26(void)
 
 	code.func3((sljit_sw)&buf, (sljit_sw)&ibuf, (sljit_sw)&dbuf);
 
-	FAILED(buf[1] != -689, "test26 case 1 failed\n");
-	FAILED(buf[2] != -16, "test26 case 2 failed\n");
-	FAILED(ibuf[1] != -2789, "test26 case 3 failed\n");
-	FAILED(ibuf[2] != -18, "test26 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -689, "test26 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -16, "test26 case 2 failed\n");
+	SLJIT_TEST_FAILED(ibuf[1] != -2789, "test26 case 3 failed\n");
+	SLJIT_TEST_FAILED(ibuf[2] != -18, "test26 case 4 failed\n");
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
-		FAILED(dbuf[1] != 5.75, "test26 case 5 failed\n");
-		FAILED(dbuf[2] != 11.5, "test26 case 6 failed\n");
-		FAILED(dbuf[3] != -2.875, "test26 case 7 failed\n");
+		SLJIT_TEST_FAILED(dbuf[1] != 5.75, "test26 case 5 failed\n");
+		SLJIT_TEST_FAILED(dbuf[2] != 11.5, "test26 case 6 failed\n");
+		SLJIT_TEST_FAILED(dbuf[3] != -2.875, "test26 case 7 failed\n");
 	}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test27(void)
+static SLJIT_TEST_FUNC test27(void *p)
 {
 #define SET_NEXT_BYTE(type) \
 		cond_set(compiler, SLJIT_R2, 0, type); \
@@ -2191,7 +2204,7 @@ static void test27(void)
 	for (i = 0; i < 37; ++i)
 		buf[i] = 10;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	/* 3 arguments passed, 3 arguments used. */
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 4, 3, 0, 0, 0);
@@ -2341,58 +2354,58 @@ static void test27(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED(buf[0] != RESULT(1), "test27 case 1 failed\n");
-	FAILED(buf[1] != RESULT(2), "test27 case 2 failed\n");
-	FAILED(buf[2] != 2, "test27 case 3 failed\n");
-	FAILED(buf[3] != 1, "test27 case 4 failed\n");
-	FAILED(buf[4] != RESULT(1), "test27 case 5 failed\n");
-	FAILED(buf[5] != RESULT(2), "test27 case 6 failed\n");
-	FAILED(buf[6] != 2, "test27 case 7 failed\n");
-	FAILED(buf[7] != 1, "test27 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != RESULT(1), "test27 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != RESULT(2), "test27 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 2, "test27 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 1, "test27 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != RESULT(1), "test27 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != RESULT(2), "test27 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 2, "test27 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test27 case 8 failed\n");
 
-	FAILED(buf[8] != 2, "test27 case 9 failed\n");
-	FAILED(buf[9] != 1, "test27 case 10 failed\n");
-	FAILED(buf[10] != 2, "test27 case 11 failed\n");
-	FAILED(buf[11] != 1, "test27 case 12 failed\n");
-	FAILED(buf[12] != 1, "test27 case 13 failed\n");
-	FAILED(buf[13] != 2, "test27 case 14 failed\n");
-	FAILED(buf[14] != 2, "test27 case 15 failed\n");
-	FAILED(buf[15] != 1, "test27 case 16 failed\n");
-	FAILED(buf[16] != 1, "test27 case 17 failed\n");
-	FAILED(buf[17] != 2, "test27 case 18 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 2, "test27 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 1, "test27 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 2, "test27 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 1, "test27 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 1, "test27 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != 2, "test27 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != 2, "test27 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf[15] != 1, "test27 case 16 failed\n");
+	SLJIT_TEST_FAILED(buf[16] != 1, "test27 case 17 failed\n");
+	SLJIT_TEST_FAILED(buf[17] != 2, "test27 case 18 failed\n");
 
-	FAILED(buf[18] != RESULT(1), "test27 case 19 failed\n");
-	FAILED(buf[19] != RESULT(2), "test27 case 20 failed\n");
-	FAILED(buf[20] != 2, "test27 case 21 failed\n");
-	FAILED(buf[21] != 1, "test27 case 22 failed\n");
+	SLJIT_TEST_FAILED(buf[18] != RESULT(1), "test27 case 19 failed\n");
+	SLJIT_TEST_FAILED(buf[19] != RESULT(2), "test27 case 20 failed\n");
+	SLJIT_TEST_FAILED(buf[20] != 2, "test27 case 21 failed\n");
+	SLJIT_TEST_FAILED(buf[21] != 1, "test27 case 22 failed\n");
 
-	FAILED(buf[22] != 5, "test27 case 23 failed\n");
-	FAILED(buf[23] != 9, "test27 case 24 failed\n");
+	SLJIT_TEST_FAILED(buf[22] != 5, "test27 case 23 failed\n");
+	SLJIT_TEST_FAILED(buf[23] != 9, "test27 case 24 failed\n");
 
-	FAILED(buf[24] != 2, "test27 case 25 failed\n");
-	FAILED(buf[25] != 1, "test27 case 26 failed\n");
+	SLJIT_TEST_FAILED(buf[24] != 2, "test27 case 25 failed\n");
+	SLJIT_TEST_FAILED(buf[25] != 1, "test27 case 26 failed\n");
 
-	FAILED(buf[26] != 1, "test27 case 27 failed\n");
-	FAILED(buf[27] != 1, "test27 case 28 failed\n");
-	FAILED(buf[28] != 1, "test27 case 29 failed\n");
-	FAILED(buf[29] != 1, "test27 case 30 failed\n");
+	SLJIT_TEST_FAILED(buf[26] != 1, "test27 case 27 failed\n");
+	SLJIT_TEST_FAILED(buf[27] != 1, "test27 case 28 failed\n");
+	SLJIT_TEST_FAILED(buf[28] != 1, "test27 case 29 failed\n");
+	SLJIT_TEST_FAILED(buf[29] != 1, "test27 case 30 failed\n");
 
-	FAILED(buf[30] != 1, "test27 case 31 failed\n");
-	FAILED(buf[31] != 0, "test27 case 32 failed\n");
+	SLJIT_TEST_FAILED(buf[30] != 1, "test27 case 31 failed\n");
+	SLJIT_TEST_FAILED(buf[31] != 0, "test27 case 32 failed\n");
 
-	FAILED(buf[32] != 2, "test27 case 33 failed\n");
-	FAILED(buf[33] != 1, "test27 case 34 failed\n");
-	FAILED(buf[34] != 2, "test27 case 35 failed\n");
-	FAILED(buf[35] != 1, "test27 case 36 failed\n");
-	FAILED(buf[36] != 10, "test27 case 37 failed\n");
+	SLJIT_TEST_FAILED(buf[32] != 2, "test27 case 33 failed\n");
+	SLJIT_TEST_FAILED(buf[33] != 1, "test27 case 34 failed\n");
+	SLJIT_TEST_FAILED(buf[34] != 2, "test27 case 35 failed\n");
+	SLJIT_TEST_FAILED(buf[35] != 1, "test27 case 36 failed\n");
+	SLJIT_TEST_FAILED(buf[36] != 10, "test27 case 37 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 #undef SET_NEXT_BYTE
 #undef RESULT
 }
 
-static void test28(void)
+static SLJIT_TEST_FUNC test28(void *p)
 {
 	/* Test mov. */
 	executable_code code;
@@ -2405,7 +2418,7 @@ static void test28(void)
 	if (verbose)
 		printf("Run test28\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = -36;
 	buf[1] = 8;
@@ -2413,7 +2426,7 @@ static void test28(void)
 	buf[3] = 10;
 	buf[4] = 0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 5, 5, 0, 0, 0);
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R3, 0, SLJIT_IMM, -234);
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R4, 0, SLJIT_MEM1(SLJIT_S0), sizeof(sljit_sw));
@@ -2443,17 +2456,17 @@ static void test28(void)
 
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 8, "test28 case 1 failed\n");
-	FAILED(buf[1] != -1872, "test28 case 2 failed\n");
-	FAILED(buf[2] != 1, "test28 case 3 failed\n");
-	FAILED(buf[3] != 2, "test28 case 4 failed\n");
-	FAILED(buf[4] != label_addr, "test28 case 5 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 8, "test28 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -1872, "test28 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 1, "test28 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 2, "test28 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != label_addr, "test28 case 5 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test29(void)
+static SLJIT_TEST_FUNC test29(void *p)
 {
 	/* Test signed/unsigned bytes and halfs. */
 	executable_code code;
@@ -2467,7 +2480,7 @@ static void test29(void)
 	for (i = 0; i < 25; i++)
 		buf[i] = 0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 5, 5, 0, 0, 0);
 
 	sljit_emit_op1(compiler, SLJIT_MOV_S8, SLJIT_R0, 0, SLJIT_IMM, -187);
@@ -2551,45 +2564,45 @@ static void test29(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 69, "test29 case 1 failed\n");
-	FAILED(buf[1] != -93, "test29 case 2 failed\n");
-	FAILED(buf[2] != 200, "test29 case 3 failed\n");
-	FAILED(buf[3] != 0xe5, "test29 case 4 failed\n");
-	FAILED(buf[4] != 19640, "test29 case 5 failed\n");
-	FAILED(buf[5] != -31005, "test29 case 6 failed\n");
-	FAILED(buf[6] != 52646, "test29 case 7 failed\n");
-	FAILED(buf[7] != 0xb0a6, "test29 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 69, "test29 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -93, "test29 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 200, "test29 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0xe5, "test29 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 19640, "test29 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != -31005, "test29 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 52646, "test29 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 0xb0a6, "test29 case 8 failed\n");
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[8] != SLJIT_W(714537581), "test29 case 9 failed\n");
-	FAILED(buf[9] != SLJIT_W(-1938520854), "test29 case 10 failed\n");
-	FAILED(buf[10] != SLJIT_W(3236202668), "test29 case 11 failed\n");
-	FAILED(buf[11] != SLJIT_W(0xf97a70b5), "test29 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != SLJIT_W(714537581), "test29 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != SLJIT_W(-1938520854), "test29 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != SLJIT_W(3236202668), "test29 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != SLJIT_W(0xf97a70b5), "test29 case 12 failed\n");
 #endif
 
-	FAILED(buf[12] != 69, "test29 case 13 failed\n");
-	FAILED(buf[13] != -93, "test29 case 14 failed\n");
-	FAILED(buf[14] != 200, "test29 case 15 failed\n");
-	FAILED(buf[15] != 0xe5, "test29 case 16 failed\n");
-	FAILED(buf[16] != 19640, "test29 case 17 failed\n");
-	FAILED(buf[17] != -31005, "test29 case 18 failed\n");
-	FAILED(buf[18] != 52646, "test29 case 19 failed\n");
-	FAILED(buf[19] != 0xb0a6, "test29 case 20 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 69, "test29 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != -93, "test29 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != 200, "test29 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf[15] != 0xe5, "test29 case 16 failed\n");
+	SLJIT_TEST_FAILED(buf[16] != 19640, "test29 case 17 failed\n");
+	SLJIT_TEST_FAILED(buf[17] != -31005, "test29 case 18 failed\n");
+	SLJIT_TEST_FAILED(buf[18] != 52646, "test29 case 19 failed\n");
+	SLJIT_TEST_FAILED(buf[19] != 0xb0a6, "test29 case 20 failed\n");
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[20] != SLJIT_W(714537581), "test29 case 21 failed\n");
-	FAILED(buf[21] != SLJIT_W(-1938520854), "test29 case 22 failed\n");
-	FAILED(buf[22] != SLJIT_W(3236202668), "test29 case 23 failed\n");
-	FAILED(buf[23] != SLJIT_W(0xf97a70b5), "test29 case 24 failed\n");
+	SLJIT_TEST_FAILED(buf[20] != SLJIT_W(714537581), "test29 case 21 failed\n");
+	SLJIT_TEST_FAILED(buf[21] != SLJIT_W(-1938520854), "test29 case 22 failed\n");
+	SLJIT_TEST_FAILED(buf[22] != SLJIT_W(3236202668), "test29 case 23 failed\n");
+	SLJIT_TEST_FAILED(buf[23] != SLJIT_W(0xf97a70b5), "test29 case 24 failed\n");
 #endif
 
-	FAILED(buf[24] != -91, "test29 case 25 failed\n");
+	SLJIT_TEST_FAILED(buf[24] != -91, "test29 case 25 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test30(void)
+static SLJIT_TEST_FUNC test30(void *p)
 {
 	/* Test unused results. */
 	executable_code code;
@@ -2599,7 +2612,7 @@ static void test30(void)
 	if (verbose)
 		printf("Run test30\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 5, 5, 0, 0, 0);
 
@@ -2646,13 +2659,13 @@ static void test30(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 9, "test30 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 9, "test30 case 1 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test31(void)
+static SLJIT_TEST_FUNC test31(void *p)
 {
 	/* Integer mul and set flags. */
 	executable_code code;
@@ -2682,7 +2695,7 @@ static void test31(void)
 	buf[10] = 3;
 	buf[11] = 3;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 3, 5, 0, 0, 0);
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, 0);
@@ -2727,27 +2740,27 @@ static void test31(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED(buf[0] != 1, "test31 case 1 failed\n");
-	FAILED(buf[1] != 2, "test31 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 1, "test31 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 2, "test31 case 2 failed\n");
 /* Qemu issues for 64 bit muls. */
 #if !(defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[2] != 1, "test31 case 3 failed\n");
-	FAILED(buf[3] != 2, "test31 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 1, "test31 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 2, "test31 case 4 failed\n");
 #endif
-	FAILED(buf[4] != 1, "test31 case 5 failed\n");
-	FAILED((buf[5] & 0xffffffff) != 0x85540c10, "test31 case 6 failed\n");
-	FAILED(buf[6] != 2, "test31 case 7 failed\n");
-	FAILED(buf[7] != 1, "test31 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 1, "test31 case 5 failed\n");
+	SLJIT_TEST_FAILED((buf[5] & 0xffffffff) != 0x85540c10, "test31 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 2, "test31 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test31 case 8 failed\n");
 #if !(defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[8] != 1, "test31 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 1, "test31 case 9 failed\n");
 #endif
-	FAILED(buf[9] != -1541, "test31 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != -1541, "test31 case 10 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test32(void)
+static SLJIT_TEST_FUNC test32(void *p)
 {
 	/* Floating point set flags. */
 	executable_code code;
@@ -2793,13 +2806,12 @@ static void test32(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test32 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	SLJIT_ASSERT(sizeof(sljit_f64) == 8 && sizeof(sljit_s32) == 4 && sizeof(dbuf[0]) == 8);
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 1, 2, 4, 0, 0);
@@ -2850,26 +2862,26 @@ static void test32(void)
 
 	code.func2((sljit_sw)&buf, (sljit_sw)&dbuf);
 
-	FAILED(buf[0] != 1, "test32 case 1 failed\n");
-	FAILED(buf[1] != 2, "test32 case 2 failed\n");
-	FAILED(buf[2] != 2, "test32 case 3 failed\n");
-	FAILED(buf[3] != 1, "test32 case 4 failed\n");
-	FAILED(buf[4] != 1, "test32 case 5 failed\n");
-	FAILED(buf[5] != 2, "test32 case 6 failed\n");
-	FAILED(buf[6] != 2, "test32 case 7 failed\n");
-	FAILED(buf[7] != 1, "test32 case 8 failed\n");
-	FAILED(buf[8] != 2, "test32 case 9 failed\n");
-	FAILED(buf[9] != 1, "test32 case 10 failed\n");
-	FAILED(buf[10] != 2, "test32 case 11 failed\n");
-	FAILED(buf[11] != 1, "test32 case 12 failed\n");
-	FAILED(buf[12] != 2, "test32 case 13 failed\n");
-	FAILED(buf[13] != 1, "test32 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 1, "test32 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 2, "test32 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 2, "test32 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 1, "test32 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 1, "test32 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 2, "test32 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 2, "test32 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test32 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 2, "test32 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 1, "test32 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 2, "test32 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 1, "test32 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 2, "test32 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != 1, "test32 case 14 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test33(void)
+static SLJIT_TEST_FUNC test33(void *p)
 {
 	/* Test setting multiple flags. */
 	executable_code code;
@@ -2891,7 +2903,7 @@ static void test33(void)
 	buf[8] = 3;
 	buf[9] = 3;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 3, 3, 0, 0, 0);
 
@@ -2955,22 +2967,22 @@ static void test33(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED(buf[0] != 0, "test33 case 1 failed\n");
-	FAILED(buf[1] != 11, "test33 case 2 failed\n");
-	FAILED(buf[2] != 1, "test33 case 3 failed\n");
-	FAILED(buf[3] != 45, "test33 case 4 failed\n");
-	FAILED(buf[4] != 13, "test33 case 5 failed\n");
-	FAILED(buf[5] != 0, "test33 case 6 failed\n");
-	FAILED(buf[6] != 0, "test33 case 7 failed\n");
-	FAILED(buf[7] != 48, "test33 case 8 failed\n");
-	FAILED(buf[8] != 50, "test33 case 9 failed\n");
-	FAILED(buf[9] != 1, "test33 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0, "test33 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 11, "test33 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 1, "test33 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 45, "test33 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 13, "test33 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0, "test33 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0, "test33 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 48, "test33 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 50, "test33 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 1, "test33 case 10 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test34(void)
+static SLJIT_TEST_FUNC test34(void *p)
 {
 	/* Test fast calls. */
 	executable_code codeA;
@@ -2993,7 +3005,7 @@ static void test34(void)
 
 	/* A */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 1, 5, 5, 0, 0, 2 * sizeof(sljit_p));
 
 	sljit_emit_op0(compiler, SLJIT_ENDBR);
@@ -3007,7 +3019,7 @@ static void test34(void)
 
 	/* B */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 1, 5, 5, 0, 0, 2 * sizeof(sljit_p));
 
 	sljit_emit_op0(compiler, SLJIT_ENDBR);
@@ -3023,7 +3035,7 @@ static void test34(void)
 
 	/* C */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 1, 5, 5, 0, 0, 2 * sizeof(sljit_p));
 
 	sljit_emit_op0(compiler, SLJIT_ENDBR);
@@ -3039,7 +3051,7 @@ static void test34(void)
 
 	/* D */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 1, 5, 5, 0, 0, 2 * sizeof(sljit_p));
 
 	sljit_emit_op0(compiler, SLJIT_ENDBR);
@@ -3054,7 +3066,7 @@ static void test34(void)
 
 	/* E */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 1, 5, 5, 0, 0, 2 * sizeof(sljit_p));
 
 	sljit_emit_fast_enter(compiler, SLJIT_MEM1(SLJIT_S0), 0);
@@ -3069,7 +3081,7 @@ static void test34(void)
 
 	/* F */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 5, 5, 0, 0, 2 * sizeof(sljit_p));
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
@@ -3082,8 +3094,8 @@ static void test34(void)
 	addr = sljit_get_label_addr(label);
 	sljit_free_compiler(compiler);
 
-	FAILED(codeF.func1((sljit_sw)&buf) != 40, "test34 case 1 failed\n");
-	FAILED(buf[0] != addr - SLJIT_RETURN_ADDRESS_OFFSET, "test34 case 2 failed\n");
+	SLJIT_TEST_FAILED(codeF.func1((sljit_sw)&buf) != 40, "test34 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != addr - SLJIT_RETURN_ADDRESS_OFFSET, "test34 case 2 failed\n");
 
 	sljit_free_code(codeA.code);
 	sljit_free_code(codeB.code);
@@ -3091,10 +3103,10 @@ static void test34(void)
 	sljit_free_code(codeD.code);
 	sljit_free_code(codeE.code);
 	sljit_free_code(codeF.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test35(void)
+static SLJIT_TEST_FUNC test35(void *p)
 {
 	/* More complicated tests for fast calls. */
 	executable_code codeA;
@@ -3115,7 +3127,7 @@ static void test35(void)
 
 	/* A */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 0, 2, 2, 0, 0, 0);
 
 	sljit_emit_fast_enter(compiler, SLJIT_MEM0(), (sljit_sw)&buf[0]);
@@ -3135,7 +3147,7 @@ static void test35(void)
 
 	/* B */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, 0, 2, 2, 0, 0, 0);
 
 	sljit_emit_op0(compiler, SLJIT_ENDBR);
@@ -3151,7 +3163,7 @@ static void test35(void)
 
 	/* C */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, 2, 2, 0, 0, 0);
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
@@ -3164,13 +3176,13 @@ static void test35(void)
 	return_addr = sljit_get_label_addr(label);
 	sljit_free_compiler(compiler);
 
-	FAILED(codeC.func0() != 12, "test35 case 1 failed\n");
-	FAILED(buf[0] != return_addr - SLJIT_RETURN_ADDRESS_OFFSET, "test35 case 2 failed\n");
+	SLJIT_TEST_FAILED(codeC.func0() != 12, "test35 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != return_addr - SLJIT_RETURN_ADDRESS_OFFSET, "test35 case 2 failed\n");
 
 	sljit_free_code(codeA.code);
 	sljit_free_code(codeB.code);
 	sljit_free_code(codeC.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
 static void cmp_test(struct sljit_compiler *compiler, sljit_s32 type, sljit_s32 src1, sljit_sw src1w, sljit_s32 src2, sljit_sw src2w)
@@ -3189,7 +3201,7 @@ static void cmp_test(struct sljit_compiler *compiler, sljit_s32 type, sljit_s32 
 }
 
 #define TEST_CASES	(7 + 10 + 12 + 11 + 4)
-static void test36(void)
+static SLJIT_TEST_FUNC test36(void *p)
 {
 	/* Compare instruction. */
 	executable_code code;
@@ -3209,7 +3221,7 @@ static void test36(void)
 	if (verbose)
 		printf("Run test36\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	for (i = 0; i < TEST_CASES; ++i)
 		buf[i] = 100;
 	data[0] = 32;
@@ -3302,11 +3314,11 @@ static void test36(void)
 	for (i = 0; i < TEST_CASES; ++i)
 		if (SLJIT_UNLIKELY(buf[i] != compare_buf[i])) {
 			printf("test36 case %d failed\n", i + 1);
-			return;
+			SLJIT_TEST_RETURN(0);
 		}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 #undef TEST_CASES
 
@@ -3318,7 +3330,7 @@ static void test36(void)
 #define RESN(n) ((n) & 0x1f)
 #endif
 
-static void test37(void)
+static SLJIT_TEST_FUNC test37(void *p)
 {
 	/* Test count leading zeroes. */
 	executable_code code;
@@ -3330,7 +3342,7 @@ static void test37(void)
 	if (verbose)
 		printf("Run test37\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	for (i = 0; i < 9; i++)
 		buf[i] = -1;
@@ -3380,34 +3392,34 @@ static void test37(void)
 	sljit_free_compiler(compiler);
 
 	code.func2((sljit_sw)&buf, (sljit_sw)&ibuf);
-	FAILED(buf[0] != RESN(27), "test37 case 1 failed\n");
-	FAILED(buf[1] != RESN(47), "test37 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != RESN(27), "test37 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != RESN(47), "test37 case 2 failed\n");
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[2] != 64, "test37 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 64, "test37 case 3 failed\n");
 #else
-	FAILED(buf[2] != 32, "test37 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 32, "test37 case 3 failed\n");
 #endif
-	FAILED(buf[3] != 0, "test37 case 4 failed\n");
-	FAILED(ibuf[0] != 32, "test37 case 5 failed\n");
-	FAILED(buf[4] != RESN(13), "test37 case 6 failed\n");
-	FAILED(buf[5] != RESN(58), "test37 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0, "test37 case 4 failed\n");
+	SLJIT_TEST_FAILED(ibuf[0] != 32, "test37 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != RESN(13), "test37 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != RESN(58), "test37 case 7 failed\n");
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[6] != 64, "test37 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 64, "test37 case 8 failed\n");
 #else
-	FAILED(buf[6] != 32, "test37 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 32, "test37 case 8 failed\n");
 #endif
-	FAILED(ibuf[1] != 4, "test37 case 9 failed\n");
+	SLJIT_TEST_FAILED(ibuf[1] != 4, "test37 case 9 failed\n");
 
-	FAILED((buf[7] & 0xffffffff) != 4, "test37 case 10 failed\n");
-	FAILED((buf[8] & 0xffffffff) != 0, "test37 case 11 failed\n");
+	SLJIT_TEST_FAILED((buf[7] & 0xffffffff) != 4, "test37 case 10 failed\n");
+	SLJIT_TEST_FAILED((buf[8] & 0xffffffff) != 0, "test37 case 11 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 #undef BITN
 #undef RESN
 
-static void test38(void)
+static SLJIT_TEST_FUNC test38(void *p)
 {
 #if (defined SLJIT_UTIL_STACK && SLJIT_UTIL_STACK)
 	/* Test stack utility. */
@@ -3426,7 +3438,7 @@ static void test38(void)
 	if (verbose)
 		printf("Run test38\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, 3, 1, 0, 0, 0);
 
@@ -3503,14 +3515,14 @@ static void test38(void)
 	sljit_free_compiler(compiler);
 
 	/* Just survive this. */
-	FAILED(code.func0() != 4567, "test38 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func0() != 4567, "test38 case 1 failed\n");
 
 	sljit_free_code(code.code);
 #endif
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test39(void)
+static SLJIT_TEST_FUNC test39(void *p)
 {
 	/* Test error handling. */
 	executable_code code;
@@ -3520,7 +3532,7 @@ static void test39(void)
 	if (verbose)
 		printf("Run test39\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	/* Such assignment should never happen in a regular program. */
 	compiler->error = -3967;
@@ -3550,25 +3562,25 @@ static void test39(void)
 	SLJIT_ASSERT(!compiler->abuf->next && !compiler->abuf->used_size);
 
 	sljit_set_compiler_memory_error(compiler);
-	FAILED(sljit_get_compiler_error(compiler) != -3967, "test39 case 1 failed\n");
+	SLJIT_TEST_FAILED(sljit_get_compiler_error(compiler) != -3967, "test39 case 1 failed\n");
 
 	code.code = sljit_generate_code(compiler);
-	FAILED(sljit_get_compiler_error(compiler) != -3967, "test39 case 2 failed\n");
-	FAILED(!!code.code, "test39 case 3 failed\n");
+	SLJIT_TEST_FAILED(sljit_get_compiler_error(compiler) != -3967, "test39 case 2 failed\n");
+	SLJIT_TEST_FAILED(!!code.code, "test39 case 3 failed\n");
 	sljit_free_compiler(compiler);
 
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
-	FAILED(sljit_get_compiler_error(compiler) != SLJIT_SUCCESS, "test39 case 4 failed\n");
+	SLJIT_TEST_FAILED(sljit_get_compiler_error(compiler) != SLJIT_SUCCESS, "test39 case 4 failed\n");
 	sljit_set_compiler_memory_error(compiler);
-	FAILED(sljit_get_compiler_error(compiler) != SLJIT_ERR_ALLOC_FAILED, "test39 case 5 failed\n");
+	SLJIT_TEST_FAILED(sljit_get_compiler_error(compiler) != SLJIT_ERR_ALLOC_FAILED, "test39 case 5 failed\n");
 	sljit_free_compiler(compiler);
 
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test40(void)
+static SLJIT_TEST_FUNC test40(void *p)
 {
 	/* Test emit_op_flags. */
 	executable_code code;
@@ -3578,7 +3590,7 @@ static void test40(void)
 	if (verbose)
 		printf("Run test40\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = -100;
 	buf[1] = -100;
 	buf[2] = -100;
@@ -3648,23 +3660,23 @@ static void test40(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != 0xbaddead, "test40 case 1 failed\n");
-	FAILED(buf[0] != 0x123457, "test40 case 2 failed\n");
-	FAILED(buf[1] != 1, "test40 case 3 failed\n");
-	FAILED(buf[2] != 0, "test40 case 4 failed\n");
-	FAILED(buf[3] != -7, "test40 case 5 failed\n");
-	FAILED(buf[4] != 0, "test40 case 6 failed\n");
-	FAILED(buf[5] != 0x89, "test40 case 7 failed\n");
-	FAILED(buf[6] != 0, "test40 case 8 failed\n");
-	FAILED(buf[7] != 1, "test40 case 9 failed\n");
-	FAILED(buf[8] != 1, "test40 case 10 failed\n");
-	FAILED(buf[9] != 0x123457, "test40 case 11 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != 0xbaddead, "test40 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0x123457, "test40 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 1, "test40 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0, "test40 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != -7, "test40 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 0, "test40 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0x89, "test40 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0, "test40 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 1, "test40 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 1, "test40 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 0x123457, "test40 case 11 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test41(void)
+static SLJIT_TEST_FUNC test41(void *p)
 {
 	/* Test inline assembly. */
 	executable_code code;
@@ -3697,7 +3709,7 @@ static void test41(void)
 		SLJIT_ASSERT(sljit_get_register_index(SLJIT_R(i)) >= 0 && sljit_get_register_index(SLJIT_R(i)) < 64);
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 3, 3, 0, 0, 0);
 
 	/* Returns with the sum of SLJIT_S0 and SLJIT_S1. */
@@ -3780,10 +3792,10 @@ static void test41(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func2(32, -11) != 21, "test41 case 1 failed\n");
-	FAILED(code.func2(1000, 234) != 1234, "test41 case 2 failed\n");
+	SLJIT_TEST_FAILED(code.func2(32, -11) != 21, "test41 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func2(1000, 234) != 1234, "test41 case 2 failed\n");
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(code.func2(SLJIT_W(0x20f0a04090c06070), SLJIT_W(0x020f0a04090c0607)) != SLJIT_W(0x22ffaa4499cc6677), "test41 case 3 failed\n");
+	SLJIT_TEST_FAILED(code.func2(SLJIT_W(0x20f0a04090c06070), SLJIT_W(0x020f0a04090c0607)) != SLJIT_W(0x22ffaa4499cc6677), "test41 case 3 failed\n");
 #endif
 
 	sljit_free_code(code.code);
@@ -3868,15 +3880,15 @@ static void test41(void)
 		sljit_free_compiler(compiler);
 
 		code.func1((sljit_sw)&buf);
-		FAILED(buf[2] != 11.25, "test41 case 3 failed\n");
+		SLJIT_TEST_FAILED(buf[2] != 11.25, "test41 case 3 failed\n");
 
 		sljit_free_code(code.code);
 	}
 
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test42(void)
+static SLJIT_TEST_FUNC test42(void *p)
 {
 	/* Test long multiply and division. */
 	executable_code code;
@@ -3887,7 +3899,7 @@ static void test42(void)
 	if (verbose)
 		printf("Run test42\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	for (i = 0; i < 7 + 4 + 8 + 8; i++)
 		buf[i] = -1;
 
@@ -4052,61 +4064,61 @@ static void test42(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED(buf[0] != -0x1fb308a, "test42 case 1 failed\n");
-	FAILED(buf[1] != 0xf50c873, "test42 case 2 failed\n");
-	FAILED(buf[2] != 0x8a0475b, "test42 case 3 failed\n");
-	FAILED(buf[3] != 0x9dc849b, "test42 case 4 failed\n");
-	FAILED(buf[4] != -0x7c69a35, "test42 case 5 failed\n");
-	FAILED(buf[5] != 0x5a4d0c4, "test42 case 6 failed\n");
-	FAILED(buf[6] != 0x9a3b06d, "test42 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != -0x1fb308a, "test42 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0xf50c873, "test42 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0x8a0475b, "test42 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 0x9dc849b, "test42 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != -0x7c69a35, "test42 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 0x5a4d0c4, "test42 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0x9a3b06d, "test42 case 7 failed\n");
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[7] != SLJIT_W(-4388959407985636971), "test42 case 8 failed\n");
-	FAILED(buf[8] != SLJIT_W(2901680654366567099), "test42 case 9 failed\n");
-	FAILED(buf[9] != SLJIT_W(-4388959407985636971), "test42 case 10 failed\n");
-	FAILED(buf[10] != SLJIT_W(-1677173957268872740), "test42 case 11 failed\n");
-	FAILED(buf[11] != SLJIT_W(2), "test42 case 12 failed\n");
-	FAILED(buf[12] != SLJIT_W(2532236178951865933), "test42 case 13 failed\n");
-	FAILED(buf[13] != SLJIT_W(-1), "test42 case 14 failed\n");
-	FAILED(buf[14] != SLJIT_W(-2177944059851366166), "test42 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != SLJIT_W(-4388959407985636971), "test42 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != SLJIT_W(2901680654366567099), "test42 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != SLJIT_W(-4388959407985636971), "test42 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != SLJIT_W(-1677173957268872740), "test42 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != SLJIT_W(2), "test42 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != SLJIT_W(2532236178951865933), "test42 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != SLJIT_W(-1), "test42 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != SLJIT_W(-2177944059851366166), "test42 case 15 failed\n");
 #else
-	FAILED(buf[7] != -1587000939, "test42 case 8 failed\n");
-	FAILED(buf[8] != 665003983, "test42 case 9 failed\n");
-	FAILED(buf[9] != -1587000939, "test42 case 10 failed\n");
-	FAILED(buf[10] != -353198352, "test42 case 11 failed\n");
-	FAILED(buf[11] != 2, "test42 case 12 failed\n");
-	FAILED(buf[12] != 768706125, "test42 case 13 failed\n");
-	FAILED(buf[13] != -1, "test42 case 14 failed\n");
-	FAILED(buf[14] != -471654166, "test42 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != -1587000939, "test42 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 665003983, "test42 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != -1587000939, "test42 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != -353198352, "test42 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 2, "test42 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 768706125, "test42 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != -1, "test42 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != -471654166, "test42 case 15 failed\n");
 #endif
 
-	FAILED(buf[15] != SLJIT_W(56), "test42 case 16 failed\n");
-	FAILED(buf[16] != SLJIT_W(58392872), "test42 case 17 failed\n");
-	FAILED(buf[17] != SLJIT_W(-47), "test42 case 18 failed\n");
-	FAILED(buf[18] != SLJIT_W(35949148), "test42 case 19 failed\n");
+	SLJIT_TEST_FAILED(buf[15] != SLJIT_W(56), "test42 case 16 failed\n");
+	SLJIT_TEST_FAILED(buf[16] != SLJIT_W(58392872), "test42 case 17 failed\n");
+	SLJIT_TEST_FAILED(buf[17] != SLJIT_W(-47), "test42 case 18 failed\n");
+	SLJIT_TEST_FAILED(buf[18] != SLJIT_W(35949148), "test42 case 19 failed\n");
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(buf[19] != SLJIT_W(0x3340bfc), "test42 case 20 failed\n");
-	FAILED(buf[20] != SLJIT_W(0x3d4af2c543), "test42 case 21 failed\n");
-	FAILED(buf[21] != SLJIT_W(-0xaf978), "test42 case 22 failed\n");
-	FAILED(buf[22] != SLJIT_W(0xa64ae42b7d6), "test42 case 23 failed\n");
+	SLJIT_TEST_FAILED(buf[19] != SLJIT_W(0x3340bfc), "test42 case 20 failed\n");
+	SLJIT_TEST_FAILED(buf[20] != SLJIT_W(0x3d4af2c543), "test42 case 21 failed\n");
+	SLJIT_TEST_FAILED(buf[21] != SLJIT_W(-0xaf978), "test42 case 22 failed\n");
+	SLJIT_TEST_FAILED(buf[22] != SLJIT_W(0xa64ae42b7d6), "test42 case 23 failed\n");
 #else
-	FAILED(buf[19] != SLJIT_W(0xda5), "test42 case 20 failed\n");
-	FAILED(buf[20] != SLJIT_W(0xb86d0), "test42 case 21 failed\n");
-	FAILED(buf[21] != SLJIT_W(-0x6b6e), "test42 case 22 failed\n");
-	FAILED(buf[22] != SLJIT_W(0xd357), "test42 case 23 failed\n");
+	SLJIT_TEST_FAILED(buf[19] != SLJIT_W(0xda5), "test42 case 20 failed\n");
+	SLJIT_TEST_FAILED(buf[20] != SLJIT_W(0xb86d0), "test42 case 21 failed\n");
+	SLJIT_TEST_FAILED(buf[21] != SLJIT_W(-0x6b6e), "test42 case 22 failed\n");
+	SLJIT_TEST_FAILED(buf[22] != SLJIT_W(0xd357), "test42 case 23 failed\n");
 #endif
 
-	FAILED(buf[23] != SLJIT_W(0x0), "test42 case 24 failed\n");
-	FAILED(buf[24] != SLJIT_W(0xf2906b14), "test42 case 25 failed\n");
-	FAILED(buf[25] != SLJIT_W(-0x8), "test42 case 26 failed\n");
-	FAILED(buf[26] != SLJIT_W(-0xa63c923), "test42 case 27 failed\n");
+	SLJIT_TEST_FAILED(buf[23] != SLJIT_W(0x0), "test42 case 24 failed\n");
+	SLJIT_TEST_FAILED(buf[24] != SLJIT_W(0xf2906b14), "test42 case 25 failed\n");
+	SLJIT_TEST_FAILED(buf[25] != SLJIT_W(-0x8), "test42 case 26 failed\n");
+	SLJIT_TEST_FAILED(buf[26] != SLJIT_W(-0xa63c923), "test42 case 27 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test43(void)
+static SLJIT_TEST_FUNC test43(void *p)
 {
 	/* Test floating point compare. */
 	executable_code code;
@@ -4127,13 +4139,12 @@ static void test43(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test43 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	dbuf[0].value = 12.125;
 	/* a NaN */
@@ -4169,19 +4180,19 @@ static void test43(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&dbuf) != 11, "test43 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&dbuf) != 11, "test43 case 1 failed\n");
 	dbuf[3].value = 12;
-	FAILED(code.func1((sljit_sw)&dbuf) != -17, "test43 case 2 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&dbuf) != -17, "test43 case 2 failed\n");
 	dbuf[1].value = 0;
-	FAILED(code.func1((sljit_sw)&dbuf) != 5, "test43 case 3 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&dbuf) != 5, "test43 case 3 failed\n");
 	dbuf[2].value = 20;
-	FAILED(code.func1((sljit_sw)&dbuf) != -2, "test43 case 4 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&dbuf) != -2, "test43 case 4 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test44(void)
+static SLJIT_TEST_FUNC test44(void *p)
 {
 	/* Test mov. */
 	executable_code code;
@@ -4191,7 +4202,7 @@ static void test44(void)
 	if (verbose)
 		printf("Run test44\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = buf + 2;
 	buf[1] = NULL;
@@ -4219,17 +4230,17 @@ static void test44(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != (sljit_sw)(buf + 2), "test44 case 1 failed\n");
-	FAILED(buf[1] != buf + 2, "test44 case 2 failed\n");
-	FAILED(buf[2] != buf + 3, "test44 case 3 failed\n");
-	FAILED(buf[3] != buf + 4, "test44 case 4 failed\n");
-	FAILED(buf[4] != buf + 2, "test44 case 5 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != (sljit_sw)(buf + 2), "test44 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != buf + 2, "test44 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != buf + 3, "test44 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != buf + 4, "test44 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != buf + 2, "test44 case 5 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test45(void)
+static SLJIT_TEST_FUNC test45(void *p)
 {
 	/* Test single precision floating point. */
 
@@ -4245,13 +4256,12 @@ static void test45(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test45 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = 5.5;
 	buf[1] = -7.25;
@@ -4322,28 +4332,28 @@ static void test45(void)
 	sljit_free_compiler(compiler);
 
 	code.func2((sljit_sw)&buf, (sljit_sw)&buf2);
-	FAILED(buf[2] != -5.5, "test45 case 1 failed\n");
-	FAILED(buf[3] != 7.25, "test45 case 2 failed\n");
-	FAILED(buf[4] != 7.25, "test45 case 3 failed\n");
-	FAILED(buf[5] != -5.5, "test45 case 4 failed\n");
-	FAILED(buf[6] != -1.75, "test45 case 5 failed\n");
-	FAILED(buf[7] != 16.0, "test45 case 6 failed\n");
-	FAILED(buf[8] != 30.25, "test45 case 7 failed\n");
-	FAILED(buf[9] != 3, "test45 case 8 failed\n");
-	FAILED(buf[10] != -5.5, "test45 case 9 failed\n");
-	FAILED(buf[11] != 7.25, "test45 case 10 failed\n");
-	FAILED(buf2[0] != 1, "test45 case 11 failed\n");
-	FAILED(buf2[1] != 2, "test45 case 12 failed\n");
-	FAILED(buf2[2] != 2, "test45 case 13 failed\n");
-	FAILED(buf2[3] != 1, "test45 case 14 failed\n");
-	FAILED(buf2[4] != 7, "test45 case 15 failed\n");
-	FAILED(buf2[5] != -1, "test45 case 16 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != -5.5, "test45 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 7.25, "test45 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 7.25, "test45 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != -5.5, "test45 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != -1.75, "test45 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 16.0, "test45 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 30.25, "test45 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 3, "test45 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != -5.5, "test45 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 7.25, "test45 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf2[0] != 1, "test45 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf2[1] != 2, "test45 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf2[2] != 2, "test45 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf2[3] != 1, "test45 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf2[4] != 7, "test45 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf2[5] != -1, "test45 case 16 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test46(void)
+static SLJIT_TEST_FUNC test46(void *p)
 {
 	/* Test sljit_emit_op_flags with 32 bit operations. */
 
@@ -4417,43 +4427,43 @@ static void test46(void)
 	sljit_free_compiler(compiler);
 
 	code.func2((sljit_sw)&buf, (sljit_sw)&buf2);
-	FAILED(buf[0] != 0, "test46 case 1 failed\n");
-	FAILED(buf[1] != -17, "test46 case 2 failed\n");
-	FAILED(buf[2] != 1, "test46 case 3 failed\n");
-	FAILED(buf[3] != -17, "test46 case 4 failed\n");
-	FAILED(buf[4] != 1, "test46 case 5 failed\n");
-	FAILED(buf[5] != -17, "test46 case 6 failed\n");
-	FAILED(buf[6] != 1, "test46 case 7 failed\n");
-	FAILED(buf[7] != -17, "test46 case 8 failed\n");
-	FAILED(buf[8] != 0, "test46 case 9 failed\n");
-	FAILED(buf[9] != -17, "test46 case 10 failed\n");
-	FAILED(buf[10] != 1, "test46 case 11 failed\n");
-	FAILED(buf[11] != -17, "test46 case 12 failed\n");
-	FAILED(buf[12] != 1, "test46 case 13 failed\n");
-	FAILED(buf[13] != -17, "test46 case 14 failed\n");
-	FAILED(buf[14] != 1, "test46 case 15 failed\n");
-	FAILED(buf[15] != -17, "test46 case 16 failed\n");
-	FAILED(buf[16] != 0, "test46 case 17 failed\n");
-	FAILED(buf[17] != -17, "test46 case 18 failed\n");
-	FAILED(buf[18] != 0, "test46 case 19 failed\n");
-	FAILED(buf[19] != -17, "test46 case 20 failed\n");
-	FAILED(buf[20] != -18, "test46 case 21 failed\n");
-	FAILED(buf[21] != -17, "test46 case 22 failed\n");
-	FAILED(buf[22] != 38, "test46 case 23 failed\n");
-	FAILED(buf[23] != -17, "test46 case 24 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0, "test46 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != -17, "test46 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 1, "test46 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != -17, "test46 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 1, "test46 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != -17, "test46 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 1, "test46 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != -17, "test46 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 0, "test46 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != -17, "test46 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 1, "test46 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != -17, "test46 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 1, "test46 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[13] != -17, "test46 case 14 failed\n");
+	SLJIT_TEST_FAILED(buf[14] != 1, "test46 case 15 failed\n");
+	SLJIT_TEST_FAILED(buf[15] != -17, "test46 case 16 failed\n");
+	SLJIT_TEST_FAILED(buf[16] != 0, "test46 case 17 failed\n");
+	SLJIT_TEST_FAILED(buf[17] != -17, "test46 case 18 failed\n");
+	SLJIT_TEST_FAILED(buf[18] != 0, "test46 case 19 failed\n");
+	SLJIT_TEST_FAILED(buf[19] != -17, "test46 case 20 failed\n");
+	SLJIT_TEST_FAILED(buf[20] != -18, "test46 case 21 failed\n");
+	SLJIT_TEST_FAILED(buf[21] != -17, "test46 case 22 failed\n");
+	SLJIT_TEST_FAILED(buf[22] != 38, "test46 case 23 failed\n");
+	SLJIT_TEST_FAILED(buf[23] != -17, "test46 case 24 failed\n");
 
-	FAILED(buf2[0] != 0, "test46 case 25 failed\n");
-	FAILED(buf2[1] != 1, "test46 case 26 failed\n");
-	FAILED(buf2[2] != 0, "test46 case 27 failed\n");
-	FAILED(buf2[3] != 1, "test46 case 28 failed\n");
-	FAILED(buf2[4] != -123, "test46 case 29 failed\n");
-	FAILED(buf2[5] != -14, "test46 case 30 failed\n");
+	SLJIT_TEST_FAILED(buf2[0] != 0, "test46 case 25 failed\n");
+	SLJIT_TEST_FAILED(buf2[1] != 1, "test46 case 26 failed\n");
+	SLJIT_TEST_FAILED(buf2[2] != 0, "test46 case 27 failed\n");
+	SLJIT_TEST_FAILED(buf2[3] != 1, "test46 case 28 failed\n");
+	SLJIT_TEST_FAILED(buf2[4] != -123, "test46 case 29 failed\n");
+	SLJIT_TEST_FAILED(buf2[5] != -14, "test46 case 30 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test47(void)
+static SLJIT_TEST_FUNC test47(void *p)
 {
 	/* Test jump optimizations. */
 	executable_code code;
@@ -4463,7 +4473,7 @@ static void test47(void)
 	if (verbose)
 		printf("Run test47\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -4490,15 +4500,15 @@ static void test47(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[0] != 0x3a5c6f, "test47 case 1 failed\n");
-	FAILED(buf[1] != 0xd37c10, "test47 case 2 failed\n");
-	FAILED(buf[2] != 0x59b48e, "test47 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 0x3a5c6f, "test47 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 0xd37c10, "test47 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 0x59b48e, "test47 case 3 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test48(void)
+static SLJIT_TEST_FUNC test48(void *p)
 {
 	/* Test floating point conversions. */
 	executable_code code;
@@ -4515,13 +4525,12 @@ static void test48(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test48 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	for (i = 0; i < 10; i++) {
 		dbuf[i] = 0.0;
 		sbuf[i] = 0.0;
@@ -4622,36 +4631,36 @@ static void test48(void)
 	sljit_free_compiler(compiler);
 
 	code.func0();
-	FAILED(dbuf[3] != 476.25, "test48 case 1 failed\n");
-	FAILED(dbuf[4] != 476.25, "test48 case 2 failed\n");
-	FAILED(dbuf[5] != 2345.0, "test48 case 3 failed\n");
-	FAILED(dbuf[6] != -6213.0, "test48 case 4 failed\n");
-	FAILED(dbuf[7] != 312.0, "test48 case 5 failed\n");
-	FAILED(dbuf[8] != -9324.0, "test48 case 6 failed\n");
-	FAILED(dbuf[9] != -77.0, "test48 case 7 failed\n");
+	SLJIT_TEST_FAILED(dbuf[3] != 476.25, "test48 case 1 failed\n");
+	SLJIT_TEST_FAILED(dbuf[4] != 476.25, "test48 case 2 failed\n");
+	SLJIT_TEST_FAILED(dbuf[5] != 2345.0, "test48 case 3 failed\n");
+	SLJIT_TEST_FAILED(dbuf[6] != -6213.0, "test48 case 4 failed\n");
+	SLJIT_TEST_FAILED(dbuf[7] != 312.0, "test48 case 5 failed\n");
+	SLJIT_TEST_FAILED(dbuf[8] != -9324.0, "test48 case 6 failed\n");
+	SLJIT_TEST_FAILED(dbuf[9] != -77.0, "test48 case 7 failed\n");
 
-	FAILED(sbuf[2] != 123.5, "test48 case 8 failed\n");
-	FAILED(sbuf[3] != 123.5, "test48 case 9 failed\n");
-	FAILED(sbuf[4] != 476.25, "test48 case 10 failed\n");
-	FAILED(sbuf[5] != -123, "test48 case 11 failed\n");
-	FAILED(sbuf[6] != 7190, "test48 case 12 failed\n");
-	FAILED(sbuf[7] != 312, "test48 case 13 failed\n");
-	FAILED(sbuf[8] != 3812, "test48 case 14 failed\n");
-	FAILED(sbuf[9] != -79.0, "test48 case 15 failed\n");
+	SLJIT_TEST_FAILED(sbuf[2] != 123.5, "test48 case 8 failed\n");
+	SLJIT_TEST_FAILED(sbuf[3] != 123.5, "test48 case 9 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != 476.25, "test48 case 10 failed\n");
+	SLJIT_TEST_FAILED(sbuf[5] != -123, "test48 case 11 failed\n");
+	SLJIT_TEST_FAILED(sbuf[6] != 7190, "test48 case 12 failed\n");
+	SLJIT_TEST_FAILED(sbuf[7] != 312, "test48 case 13 failed\n");
+	SLJIT_TEST_FAILED(sbuf[8] != 3812, "test48 case 14 failed\n");
+	SLJIT_TEST_FAILED(sbuf[9] != -79.0, "test48 case 15 failed\n");
 
-	FAILED(wbuf[1] != -367, "test48 case 16 failed\n");
-	FAILED(wbuf[2] != 917, "test48 case 17 failed\n");
-	FAILED(wbuf[3] != 476, "test48 case 18 failed\n");
-	FAILED(wbuf[4] != -476, "test48 case 19 failed\n");
+	SLJIT_TEST_FAILED(wbuf[1] != -367, "test48 case 16 failed\n");
+	SLJIT_TEST_FAILED(wbuf[2] != 917, "test48 case 17 failed\n");
+	SLJIT_TEST_FAILED(wbuf[3] != 476, "test48 case 18 failed\n");
+	SLJIT_TEST_FAILED(wbuf[4] != -476, "test48 case 19 failed\n");
 
-	FAILED(ibuf[2] != -917, "test48 case 20 failed\n");
-	FAILED(ibuf[3] != -1689, "test48 case 21 failed\n");
+	SLJIT_TEST_FAILED(ibuf[2] != -917, "test48 case 20 failed\n");
+	SLJIT_TEST_FAILED(ibuf[3] != -1689, "test48 case 21 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test49(void)
+static SLJIT_TEST_FUNC test49(void *p)
 {
 	/* Test floating point conversions. */
 	executable_code code;
@@ -4670,13 +4679,12 @@ static void test49(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test49 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	for (i = 0; i < 9; i++) {
 		dbuf_ptr[i << 1] = -1;
@@ -4746,50 +4754,50 @@ static void test49(void)
 
 	code.func0();
 
-	FAILED(dbuf_ptr[(1 * 2) + 0] != -1, "test49 case 1 failed\n");
-	FAILED(dbuf_ptr[(1 * 2) + 1] != -1, "test49 case 2 failed\n");
-	FAILED(dbuf[2] != -879.75, "test49 case 3 failed\n");
-	FAILED(dbuf_ptr[(3 * 2) + 0] != -1, "test49 case 4 failed\n");
-	FAILED(dbuf_ptr[(3 * 2) + 1] != -1, "test49 case 5 failed\n");
-	FAILED(dbuf[4] != 345, "test49 case 6 failed\n");
-	FAILED(dbuf_ptr[(5 * 2) + 0] != -1, "test49 case 7 failed\n");
-	FAILED(dbuf_ptr[(5 * 2) + 1] != -1, "test49 case 8 failed\n");
-	FAILED(dbuf[6] != -249, "test49 case 9 failed\n");
-	FAILED(dbuf_ptr[(7 * 2) + 0] != -1, "test49 case 10 failed\n");
-	FAILED(dbuf_ptr[(7 * 2) + 1] != -1, "test49 case 11 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(1 * 2) + 0] != -1, "test49 case 1 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(1 * 2) + 1] != -1, "test49 case 2 failed\n");
+	SLJIT_TEST_FAILED(dbuf[2] != -879.75, "test49 case 3 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(3 * 2) + 0] != -1, "test49 case 4 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(3 * 2) + 1] != -1, "test49 case 5 failed\n");
+	SLJIT_TEST_FAILED(dbuf[4] != 345, "test49 case 6 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(5 * 2) + 0] != -1, "test49 case 7 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(5 * 2) + 1] != -1, "test49 case 8 failed\n");
+	SLJIT_TEST_FAILED(dbuf[6] != -249, "test49 case 9 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(7 * 2) + 0] != -1, "test49 case 10 failed\n");
+	SLJIT_TEST_FAILED(dbuf_ptr[(7 * 2) + 1] != -1, "test49 case 11 failed\n");
 
-	FAILED(sbuf_ptr[1] != -1, "test49 case 12 failed\n");
-	FAILED(sbuf[2] != 673.75, "test49 case 13 failed\n");
-	FAILED(sbuf_ptr[3] != -1, "test49 case 14 failed\n");
-	FAILED(sbuf[4] != 345, "test49 case 15 failed\n");
-	FAILED(sbuf_ptr[5] != -1, "test49 case 16 failed\n");
-	FAILED(sbuf[6] != -249, "test49 case 17 failed\n");
-	FAILED(sbuf_ptr[7] != -1, "test49 case 18 failed\n");
+	SLJIT_TEST_FAILED(sbuf_ptr[1] != -1, "test49 case 12 failed\n");
+	SLJIT_TEST_FAILED(sbuf[2] != 673.75, "test49 case 13 failed\n");
+	SLJIT_TEST_FAILED(sbuf_ptr[3] != -1, "test49 case 14 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != 345, "test49 case 15 failed\n");
+	SLJIT_TEST_FAILED(sbuf_ptr[5] != -1, "test49 case 16 failed\n");
+	SLJIT_TEST_FAILED(sbuf[6] != -249, "test49 case 17 failed\n");
+	SLJIT_TEST_FAILED(sbuf_ptr[7] != -1, "test49 case 18 failed\n");
 
-	FAILED(wbuf[1] != -1, "test49 case 19 failed\n");
-	FAILED(wbuf[2] != 673, "test49 case 20 failed\n");
-	FAILED(wbuf[3] != -1, "test49 case 21 failed\n");
-	FAILED(wbuf[4] != -879, "test49 case 22 failed\n");
-	FAILED(wbuf[5] != -1, "test49 case 23 failed\n");
+	SLJIT_TEST_FAILED(wbuf[1] != -1, "test49 case 19 failed\n");
+	SLJIT_TEST_FAILED(wbuf[2] != 673, "test49 case 20 failed\n");
+	SLJIT_TEST_FAILED(wbuf[3] != -1, "test49 case 21 failed\n");
+	SLJIT_TEST_FAILED(wbuf[4] != -879, "test49 case 22 failed\n");
+	SLJIT_TEST_FAILED(wbuf[5] != -1, "test49 case 23 failed\n");
 
-	FAILED(ibuf[1] != -1, "test49 case 24 failed\n");
-	FAILED(ibuf[2] != 673, "test49 case 25 failed\n");
-	FAILED(ibuf[3] != -1, "test49 case 26 failed\n");
-	FAILED(ibuf[4] != -879, "test49 case 27 failed\n");
-	FAILED(ibuf[5] != -1, "test49 case 28 failed\n");
+	SLJIT_TEST_FAILED(ibuf[1] != -1, "test49 case 24 failed\n");
+	SLJIT_TEST_FAILED(ibuf[2] != 673, "test49 case 25 failed\n");
+	SLJIT_TEST_FAILED(ibuf[3] != -1, "test49 case 26 failed\n");
+	SLJIT_TEST_FAILED(ibuf[4] != -879, "test49 case 27 failed\n");
+	SLJIT_TEST_FAILED(ibuf[5] != -1, "test49 case 28 failed\n");
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
-	FAILED(dbuf[8] != (sljit_f64)SLJIT_W(0x4455667788), "test49 case 29 failed\n");
-	FAILED(dbuf[9] != (sljit_f64)SLJIT_W(0x66554433), "test49 case 30 failed\n");
-	FAILED(wbuf[8] != SLJIT_W(0x1122334455), "test48 case 31 failed\n");
-	FAILED(ibuf[8] == 0x4455, "test48 case 32 failed\n");
+	SLJIT_TEST_FAILED(dbuf[8] != (sljit_f64)SLJIT_W(0x4455667788), "test49 case 29 failed\n");
+	SLJIT_TEST_FAILED(dbuf[9] != (sljit_f64)SLJIT_W(0x66554433), "test49 case 30 failed\n");
+	SLJIT_TEST_FAILED(wbuf[8] != SLJIT_W(0x1122334455), "test48 case 31 failed\n");
+	SLJIT_TEST_FAILED(ibuf[8] == 0x4455, "test48 case 32 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test50(void)
+static SLJIT_TEST_FUNC test50(void *p)
 {
 	/* Test stack and floating point operations. */
 	executable_code code;
@@ -4806,13 +4814,12 @@ static void test50(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test50 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sbuf[0] = 245.5;
 	sbuf[1] = -100.25;
@@ -4858,19 +4865,19 @@ static void test50(void)
 
 	code.func1((sljit_sw)&sbuf);
 
-	FAILED(sbuf[3] != 245.5, "test50 case 1 failed\n");
-	FAILED(sbuf[4] != 145.25, "test50 case 2 failed\n");
-	FAILED(sbuf[5] != 5934, "test50 case 3 failed\n");
-	FAILED(sbuf[6] != 713.75, "test50 case 4 failed\n");
+	SLJIT_TEST_FAILED(sbuf[3] != 245.5, "test50 case 1 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != 145.25, "test50 case 2 failed\n");
+	SLJIT_TEST_FAILED(sbuf[5] != 5934, "test50 case 3 failed\n");
+	SLJIT_TEST_FAILED(sbuf[6] != 713.75, "test50 case 4 failed\n");
 #if !(defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86)
-	FAILED(!result, "test50 case 5 failed\n");
+	SLJIT_TEST_FAILED(!result, "test50 case 5 failed\n");
 #endif
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test51(void)
+static SLJIT_TEST_FUNC test51(void *p)
 {
 	/* Test all registers provided by the CPU. */
 	executable_code code;
@@ -4882,7 +4889,7 @@ static void test51(void)
 	if (verbose)
 		printf("Run test51\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	buf[0] = 39;
 
@@ -4932,7 +4939,7 @@ static void test51(void)
 
 	code.func0();
 
-	FAILED(buf[1] != (39 * 5 * (SLJIT_NUMBER_OF_REGISTERS - 2)), "test51 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != (39 * 5 * (SLJIT_NUMBER_OF_REGISTERS - 2)), "test51 case 1 failed\n");
 
 	sljit_free_code(code.code);
 
@@ -4940,7 +4947,7 @@ static void test51(void)
 
 	compiler = sljit_create_compiler(NULL);
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, SLJIT_NUMBER_OF_SCRATCH_REGISTERS, SLJIT_NUMBER_OF_SAVED_REGISTERS, 0, 0, 0);
 
@@ -4964,7 +4971,7 @@ static void test51(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func0() != (SLJIT_NUMBER_OF_SCRATCH_REGISTERS * 35 + SLJIT_NUMBER_OF_SAVED_REGISTERS * 17), "test51 case 2 failed\n");
+	SLJIT_TEST_FAILED(code.func0() != (SLJIT_NUMBER_OF_SCRATCH_REGISTERS * 35 + SLJIT_NUMBER_OF_SAVED_REGISTERS * 17), "test51 case 2 failed\n");
 
 	sljit_free_code(code.code);
 
@@ -4972,7 +4979,7 @@ static void test51(void)
 
 	compiler = sljit_create_compiler(NULL);
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, SLJIT_NUMBER_OF_SCRATCH_REGISTERS, SLJIT_NUMBER_OF_SAVED_REGISTERS, 0, 0, 0);
 
@@ -4996,13 +5003,13 @@ static void test51(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func0() != (SLJIT_NUMBER_OF_SCRATCH_REGISTERS * 43 + SLJIT_NUMBER_OF_SAVED_REGISTERS * 68), "test51 case 3 failed\n");
+	SLJIT_TEST_FAILED(code.func0() != (SLJIT_NUMBER_OF_SCRATCH_REGISTERS * 43 + SLJIT_NUMBER_OF_SAVED_REGISTERS * 68), "test51 case 3 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test52(void)
+static SLJIT_TEST_FUNC test52(void *p)
 {
 	/* Test all registers provided by the CPU. */
 	executable_code code;
@@ -5017,14 +5024,13 @@ static void test52(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test52 skipped\n");
-		successful_tests++;
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
 	/* Next test. */
 
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 6.25;
 	buf[1] = 17.75;
 
@@ -5053,14 +5059,14 @@ static void test52(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[2] != (SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS * 17.75 + SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS * 6.25), "test52 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != (SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS * 17.75 + SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS * 6.25), "test52 case 1 failed\n");
 
 	sljit_free_code(code.code);
 
 	/* Next test. */
 
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = -32.5;
 	buf[1] = -11.25;
 
@@ -5089,13 +5095,13 @@ static void test52(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
-	FAILED(buf[2] != (SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS * -11.25 + SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS * -32.5), "test52 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != (SLJIT_NUMBER_OF_SCRATCH_FLOAT_REGISTERS * -11.25 + SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS * -32.5), "test52 case 2 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test53(void)
+static SLJIT_TEST_FUNC test53(void *p)
 {
 	/* Check SLJIT_DOUBLE_ALIGNMENT. */
 	executable_code code;
@@ -5105,7 +5111,7 @@ static void test53(void)
 	if (verbose)
 		printf("Run test53\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = -1;
 
 	sljit_emit_enter(compiler, SLJIT_F64_ALIGNMENT, SLJIT_ARG1(SW), 1, 1, 0, 0, 2 * sizeof(sljit_sw));
@@ -5121,14 +5127,14 @@ static void test53(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED((buf[0] & (sizeof(sljit_f64) - 1)) != 0, "test53 case 1 failed\n");
+	SLJIT_TEST_FAILED((buf[0] & (sizeof(sljit_f64) - 1)) != 0, "test53 case 1 failed\n");
 
 	sljit_free_code(code.code);
 
 	/* Next test. */
 
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = -1;
 
 	/* One more saved register to break the alignment on x86-32. */
@@ -5145,13 +5151,13 @@ static void test53(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED((buf[0] & (sizeof(sljit_f64) - 1)) != 0, "test53 case 2 failed\n");
+	SLJIT_TEST_FAILED((buf[0] & (sizeof(sljit_f64) - 1)) != 0, "test53 case 2 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test54(void)
+static SLJIT_TEST_FUNC test54(void *p)
 {
 	/* Check cmov. */
 	executable_code code;
@@ -5177,7 +5183,7 @@ static void test54(void)
 	if (verbose)
 		printf("Run test54\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	for (i = 0; i < 19; i++)
 		buf[i] = 0;
@@ -5303,39 +5309,39 @@ static void test54(void)
 
 	code.func3((sljit_sw)&buf, (sljit_sw)&ibuf, (sljit_sw)&sbuf);
 
-	FAILED(buf[0] != 17, "test54 case 1 failed\n");
-	FAILED(buf[1] != 34, "test54 case 2 failed\n");
-	FAILED(buf[2] != 24, "test54 case 3 failed\n");
-	FAILED(buf[3] != 78, "test54 case 4 failed\n");
-	FAILED(buf[4] != large_num, "test54 case 5 failed\n");
-	FAILED(buf[5] != -45, "test54 case 6 failed\n");
-	FAILED(buf[6] != 35, "test54 case 7 failed\n");
-	FAILED(buf[7] != 71, "test54 case 8 failed\n");
-	FAILED(buf[8] != -29, "test54 case 9 failed\n");
-	FAILED(buf[9] != -12, "test54 case 10 failed\n");
-	FAILED(buf[10] != 21, "test54 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != 17, "test54 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 34, "test54 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != 24, "test54 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 78, "test54 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != large_num, "test54 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != -45, "test54 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 35, "test54 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 71, "test54 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != -29, "test54 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != -12, "test54 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 21, "test54 case 11 failed\n");
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
-		FAILED(buf[11] != 16, "test54 case 12 failed\n");
-		FAILED(buf[12] != -45, "test54 case 13 failed\n");
-		FAILED(buf[13] != 33, "test54 case 14 failed\n");
-		FAILED(buf[14] != 8, "test54 case 15 failed\n");
-		FAILED(buf[15] != -60, "test54 case 16 failed\n");
-		FAILED(buf[16] != 31, "test54 case 17 failed\n");
-		FAILED(buf[17] != 53, "test54 case 18 failed\n");
-		FAILED(buf[18] != 59, "test54 case 19 failed\n");
+		SLJIT_TEST_FAILED(buf[11] != 16, "test54 case 12 failed\n");
+		SLJIT_TEST_FAILED(buf[12] != -45, "test54 case 13 failed\n");
+		SLJIT_TEST_FAILED(buf[13] != 33, "test54 case 14 failed\n");
+		SLJIT_TEST_FAILED(buf[14] != 8, "test54 case 15 failed\n");
+		SLJIT_TEST_FAILED(buf[15] != -60, "test54 case 16 failed\n");
+		SLJIT_TEST_FAILED(buf[16] != 31, "test54 case 17 failed\n");
+		SLJIT_TEST_FAILED(buf[17] != 53, "test54 case 18 failed\n");
+		SLJIT_TEST_FAILED(buf[18] != 59, "test54 case 19 failed\n");
 	}
 
-	FAILED(ibuf[0] != 200, "test54 case 12 failed\n");
-	FAILED(ibuf[1] != 95, "test54 case 13 failed\n");
-	FAILED(ibuf[2] != 56, "test54 case 14 failed\n");
-	FAILED(ibuf[3] != -63, "test54 case 15 failed\n");
+	SLJIT_TEST_FAILED(ibuf[0] != 200, "test54 case 12 failed\n");
+	SLJIT_TEST_FAILED(ibuf[1] != 95, "test54 case 13 failed\n");
+	SLJIT_TEST_FAILED(ibuf[2] != 56, "test54 case 14 failed\n");
+	SLJIT_TEST_FAILED(ibuf[3] != -63, "test54 case 15 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test55(void)
+static SLJIT_TEST_FUNC test55(void *p)
 {
 	/* Check value preservation. */
 	executable_code code;
@@ -5346,7 +5352,7 @@ static void test55(void)
 	if (verbose)
 		printf("Run test55\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 
@@ -5390,14 +5396,14 @@ static void test55(void)
 
 	code.func0();
 
-	FAILED(buf[0] != (SLJIT_NUMBER_OF_REGISTERS - 2) * 118 + 217, "test55 case 1 failed\n");
-	FAILED(buf[1] != (SLJIT_NUMBER_OF_REGISTERS - 1) * 146 + 217, "test55 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != (SLJIT_NUMBER_OF_REGISTERS - 2) * 118 + 217, "test55 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != (SLJIT_NUMBER_OF_REGISTERS - 1) * 146 + 217, "test55 case 2 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test56(void)
+static SLJIT_TEST_FUNC test56(void *p)
 {
 	/* Check integer substraction with negative immediate. */
 	executable_code code;
@@ -5411,7 +5417,7 @@ static void test56(void)
 	for (i = 0; i < 13; i++)
 		buf[i] = 77;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 3, 1, 0, 0, 0);
 
@@ -5455,25 +5461,25 @@ static void test56(void)
 
 	code.func1((sljit_sw)&buf);
 
-	FAILED(buf[0] != (181 << 12), "test56 case 1 failed\n");
-	FAILED(buf[1] != 1, "test56 case 2 failed\n");
-	FAILED(buf[2] != (181 << 12), "test56 case 3 failed\n");
-	FAILED(buf[3] != 1, "test56 case 4 failed\n");
-	FAILED(buf[4] != 1, "test56 case 5 failed\n");
-	FAILED(buf[5] != 1, "test56 case 6 failed\n");
-	FAILED(buf[6] != 0, "test56 case 7 failed\n");
-	FAILED(buf[7] != 0, "test56 case 8 failed\n");
-	FAILED(buf[8] != 181, "test56 case 9 failed\n");
-	FAILED(buf[9] != 1, "test56 case 10 failed\n");
-	FAILED(buf[10] != 1, "test56 case 11 failed\n");
-	FAILED(buf[11] != 1, "test56 case 12 failed\n");
-	FAILED(buf[12] != 1, "test56 case 13 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != (181 << 12), "test56 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != 1, "test56 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != (181 << 12), "test56 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != 1, "test56 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != 1, "test56 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[5] != 1, "test56 case 6 failed\n");
+	SLJIT_TEST_FAILED(buf[6] != 0, "test56 case 7 failed\n");
+	SLJIT_TEST_FAILED(buf[7] != 0, "test56 case 8 failed\n");
+	SLJIT_TEST_FAILED(buf[8] != 181, "test56 case 9 failed\n");
+	SLJIT_TEST_FAILED(buf[9] != 1, "test56 case 10 failed\n");
+	SLJIT_TEST_FAILED(buf[10] != 1, "test56 case 11 failed\n");
+	SLJIT_TEST_FAILED(buf[11] != 1, "test56 case 12 failed\n");
+	SLJIT_TEST_FAILED(buf[12] != 1, "test56 case 13 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test57(void)
+static SLJIT_TEST_FUNC test57(void *p)
 {
 	/* Check prefetch instructions. */
 	executable_code code;
@@ -5485,7 +5491,7 @@ static void test57(void)
 	if (verbose)
 		printf("Run test57\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, 3, 1, 0, 0, 0);
 
@@ -5518,20 +5524,20 @@ static void test57(void)
 	code.func0();
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_PREFETCH)) {
-		FAILED(addr[0] == addr[1], "test57 case 1 failed\n");
-		FAILED(addr[1] == addr[2], "test57 case 2 failed\n");
-		FAILED(addr[2] == addr[3], "test57 case 3 failed\n");
-		FAILED(addr[3] == addr[4], "test57 case 4 failed\n");
+		SLJIT_TEST_FAILED(addr[0] == addr[1], "test57 case 1 failed\n");
+		SLJIT_TEST_FAILED(addr[1] == addr[2], "test57 case 2 failed\n");
+		SLJIT_TEST_FAILED(addr[2] == addr[3], "test57 case 3 failed\n");
+		SLJIT_TEST_FAILED(addr[3] == addr[4], "test57 case 4 failed\n");
 	}
 	else {
-		FAILED(addr[0] != addr[1], "test57 case 1 failed\n");
-		FAILED(addr[1] != addr[2], "test57 case 2 failed\n");
-		FAILED(addr[2] != addr[3], "test57 case 3 failed\n");
-		FAILED(addr[3] != addr[4], "test57 case 4 failed\n");
+		SLJIT_TEST_FAILED(addr[0] != addr[1], "test57 case 1 failed\n");
+		SLJIT_TEST_FAILED(addr[1] != addr[2], "test57 case 2 failed\n");
+		SLJIT_TEST_FAILED(addr[2] != addr[3], "test57 case 3 failed\n");
+		SLJIT_TEST_FAILED(addr[3] != addr[4], "test57 case 4 failed\n");
 	}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
 static sljit_f64 SLJIT_FUNC test58_f1(sljit_f32 a, sljit_f32 b, sljit_f64 c)
@@ -5564,7 +5570,7 @@ static sljit_sw SLJIT_FUNC test58_f6(sljit_f64 a, sljit_sw b)
 	return (sljit_sw)a + b;
 }
 
-static void test58(void)
+static SLJIT_TEST_FUNC test58(void *p)
 {
 	/* Check function calls with floating point arguments. */
 	executable_code code;
@@ -5580,10 +5586,9 @@ static void test58(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test58 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
 	dbuf[0] = 5.25;
@@ -5603,7 +5608,7 @@ static void test58(void)
 	wbuf[0] = 0;
 	wbuf[1] = 0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), 3, 3, 4, 0, sizeof(sljit_sw));
 
@@ -5676,17 +5681,17 @@ static void test58(void)
 
 	code.func3((sljit_sw)&dbuf, (sljit_sw)&sbuf, (sljit_sw)&wbuf);
 
-	FAILED(dbuf[1] != 8.5, "test58 case 1 failed\n");
-	FAILED(dbuf[3] != 0.5, "test58 case 2 failed\n");
-	FAILED(sbuf[3] != 17.75, "test58 case 3 failed\n");
-	FAILED(dbuf[4] != 11.75, "test58 case 4 failed\n");
-	FAILED(dbuf[5] != -9.5, "test58 case 5 failed\n");
-	FAILED(sbuf[4] != 12, "test58 case 6 failed\n");
-	FAILED(wbuf[0] != SLJIT_FUNC_OFFSET(test58_f6) - 18, "test58 case 7 failed\n");
-	FAILED(wbuf[1] != 301, "test58 case 8 failed\n");
+	SLJIT_TEST_FAILED(dbuf[1] != 8.5, "test58 case 1 failed\n");
+	SLJIT_TEST_FAILED(dbuf[3] != 0.5, "test58 case 2 failed\n");
+	SLJIT_TEST_FAILED(sbuf[3] != 17.75, "test58 case 3 failed\n");
+	SLJIT_TEST_FAILED(dbuf[4] != 11.75, "test58 case 4 failed\n");
+	SLJIT_TEST_FAILED(dbuf[5] != -9.5, "test58 case 5 failed\n");
+	SLJIT_TEST_FAILED(sbuf[4] != 12, "test58 case 6 failed\n");
+	SLJIT_TEST_FAILED(wbuf[0] != SLJIT_FUNC_OFFSET(test58_f6) - 18, "test58 case 7 failed\n");
+	SLJIT_TEST_FAILED(wbuf[1] != 301, "test58 case 8 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
 static sljit_sw SLJIT_FUNC test59_f1(sljit_sw a, sljit_s32 b, sljit_sw c, sljit_sw d)
@@ -5714,7 +5719,7 @@ static sljit_f32 SLJIT_FUNC test59_f5(sljit_f32 a, sljit_f64 b, sljit_f32 c, slj
 	return (sljit_f32)(a + b + c + d);
 }
 
-static void test59(void)
+static SLJIT_TEST_FUNC test59(void *p)
 {
 	/* Check function calls with four arguments. */
 	executable_code code;
@@ -5745,7 +5750,7 @@ static void test59(void)
 		sbuf[3] = 0.0;
 	}
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), 4, 3, 4, 0, sizeof(sljit_sw));
 
@@ -5818,22 +5823,22 @@ static void test59(void)
 
 	code.func3((sljit_sw)&wbuf, (sljit_sw)&dbuf, (sljit_sw)&sbuf);
 
-	FAILED(wbuf[0] != -27, "test59 case 1 failed\n");
-	FAILED(wbuf[1] != 36, "test59 case 2 failed\n");
-	FAILED(wbuf[2] != 65, "test59 case 3 failed\n");
-	FAILED(wbuf[4] != (sljit_sw)wbuf + 134, "test59 case 4 failed\n");
+	SLJIT_TEST_FAILED(wbuf[0] != -27, "test59 case 1 failed\n");
+	SLJIT_TEST_FAILED(wbuf[1] != 36, "test59 case 2 failed\n");
+	SLJIT_TEST_FAILED(wbuf[2] != 65, "test59 case 3 failed\n");
+	SLJIT_TEST_FAILED(wbuf[4] != (sljit_sw)wbuf + 134, "test59 case 4 failed\n");
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
-		FAILED(wbuf[5] != -88, "test59 case 5 failed\n");
-		FAILED(sbuf[2] != 79.75, "test59 case 6 failed\n");
-		FAILED(sbuf[3] != 8.625, "test59 case 7 failed\n");
+		SLJIT_TEST_FAILED(wbuf[5] != -88, "test59 case 5 failed\n");
+		SLJIT_TEST_FAILED(sbuf[2] != 79.75, "test59 case 6 failed\n");
+		SLJIT_TEST_FAILED(sbuf[3] != 8.625, "test59 case 7 failed\n");
 	}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test60(void)
+static SLJIT_TEST_FUNC test60(void *p)
 {
 	/* Test memory accesses with pre/post updates. */
 	executable_code code;
@@ -5871,7 +5876,7 @@ static void test60(void)
 	ibuf[1] = 0;
 	ibuf[2] = 0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), 4, 3, 4, 0, sizeof(sljit_sw));
 
@@ -5976,48 +5981,48 @@ static void test60(void)
 
 	code.func3((sljit_sw)&wbuf, (sljit_sw)&bbuf, (sljit_sw)&ibuf);
 
-	FAILED(sizeof(expected) != sizeof(supported) / sizeof(sljit_s32), "test60 case 1 failed\n");
+	SLJIT_TEST_FAILED(sizeof(expected) != sizeof(supported) / sizeof(sljit_s32), "test60 case 1 failed\n");
 
 	for (i = 0; i < sizeof(expected); i++) {
 		if (expected[i]) {
 			if (supported[i] != SLJIT_SUCCESS) {
 				printf("tast60 case %d should be supported\n", i + 1);
-				return;
+				SLJIT_TEST_RETURN(0);
 			}
 		} else {
 			if (supported[i] == SLJIT_SUCCESS) {
 				printf("test60 case %d should not be supported\n", i + 1);
-				return;
+				SLJIT_TEST_RETURN(0);
 			}
 		}
 	}
 
-	FAILED(supported[0] == SLJIT_SUCCESS && wbuf[0] != -887766, "test60 case 2 failed\n");
-	FAILED(supported[0] == SLJIT_SUCCESS && wbuf[1] != (sljit_sw)(wbuf + 2), "test60 case 3 failed\n");
-	FAILED(supported[1] == SLJIT_SUCCESS && wbuf[3] != -13, "test60 case 4 failed\n");
-	FAILED(supported[1] == SLJIT_SUCCESS && wbuf[4] != (sljit_sw)(bbuf), "test60 case 5 failed\n");
-	FAILED(supported[2] == SLJIT_SUCCESS && wbuf[5] != -5678, "test60 case 6 failed\n");
-	FAILED(supported[2] == SLJIT_SUCCESS && wbuf[6] != (sljit_sw)(ibuf), "test60 case 7 failed\n");
-	FAILED(supported[3] == SLJIT_SUCCESS && ibuf[1] != -8765, "test60 case 8 failed\n");
-	FAILED(supported[3] == SLJIT_SUCCESS && wbuf[7] != (sljit_sw)(ibuf + 1), "test60 case 9 failed\n");
-	FAILED(supported[4] == SLJIT_SUCCESS && bbuf[0] != -121, "test60 case 10 failed\n");
-	FAILED(supported[4] == SLJIT_SUCCESS && wbuf[8] != (sljit_sw)(bbuf) - 128 * sizeof(sljit_s8), "test60 case 11 failed\n");
-	FAILED(supported[5] == SLJIT_SUCCESS && wbuf[9] != -881199, "test60 case 12 failed\n");
-	FAILED(supported[5] == SLJIT_SUCCESS && wbuf[10] != (sljit_sw)(wbuf + 9), "test60 case 13 failed\n");
-	FAILED(supported[6] == SLJIT_SUCCESS && wbuf[11] != -5678, "test60 case 14 failed\n");
-	FAILED(supported[6] == SLJIT_SUCCESS && wbuf[12] != (sljit_sw)(ibuf), "test60 case 15 failed\n");
-	FAILED(supported[7] == SLJIT_SUCCESS && ibuf[2] != -7890, "test60 case 16 failed\n");
-	FAILED(supported[7] == SLJIT_SUCCESS && wbuf[13] != (sljit_sw)(ibuf + 2), "test60 case 17 failed\n");
-	FAILED(supported[8] == SLJIT_SUCCESS && wbuf[14] != -887766, "test60 case 18 failed\n");
-	FAILED(supported[8] == SLJIT_SUCCESS && wbuf[15] != (sljit_sw)(wbuf + 10), "test60 case 19 failed\n");
-	FAILED(supported[9] == SLJIT_SUCCESS && wbuf[16] != -13, "test60 case 20 failed\n");
-	FAILED(supported[9] == SLJIT_SUCCESS && wbuf[17] != (sljit_sw)(bbuf), "test60 case 21 failed\n");
+	SLJIT_TEST_FAILED(supported[0] == SLJIT_SUCCESS && wbuf[0] != -887766, "test60 case 2 failed\n");
+	SLJIT_TEST_FAILED(supported[0] == SLJIT_SUCCESS && wbuf[1] != (sljit_sw)(wbuf + 2), "test60 case 3 failed\n");
+	SLJIT_TEST_FAILED(supported[1] == SLJIT_SUCCESS && wbuf[3] != -13, "test60 case 4 failed\n");
+	SLJIT_TEST_FAILED(supported[1] == SLJIT_SUCCESS && wbuf[4] != (sljit_sw)(bbuf), "test60 case 5 failed\n");
+	SLJIT_TEST_FAILED(supported[2] == SLJIT_SUCCESS && wbuf[5] != -5678, "test60 case 6 failed\n");
+	SLJIT_TEST_FAILED(supported[2] == SLJIT_SUCCESS && wbuf[6] != (sljit_sw)(ibuf), "test60 case 7 failed\n");
+	SLJIT_TEST_FAILED(supported[3] == SLJIT_SUCCESS && ibuf[1] != -8765, "test60 case 8 failed\n");
+	SLJIT_TEST_FAILED(supported[3] == SLJIT_SUCCESS && wbuf[7] != (sljit_sw)(ibuf + 1), "test60 case 9 failed\n");
+	SLJIT_TEST_FAILED(supported[4] == SLJIT_SUCCESS && bbuf[0] != -121, "test60 case 10 failed\n");
+	SLJIT_TEST_FAILED(supported[4] == SLJIT_SUCCESS && wbuf[8] != (sljit_sw)(bbuf) - 128 * sizeof(sljit_s8), "test60 case 11 failed\n");
+	SLJIT_TEST_FAILED(supported[5] == SLJIT_SUCCESS && wbuf[9] != -881199, "test60 case 12 failed\n");
+	SLJIT_TEST_FAILED(supported[5] == SLJIT_SUCCESS && wbuf[10] != (sljit_sw)(wbuf + 9), "test60 case 13 failed\n");
+	SLJIT_TEST_FAILED(supported[6] == SLJIT_SUCCESS && wbuf[11] != -5678, "test60 case 14 failed\n");
+	SLJIT_TEST_FAILED(supported[6] == SLJIT_SUCCESS && wbuf[12] != (sljit_sw)(ibuf), "test60 case 15 failed\n");
+	SLJIT_TEST_FAILED(supported[7] == SLJIT_SUCCESS && ibuf[2] != -7890, "test60 case 16 failed\n");
+	SLJIT_TEST_FAILED(supported[7] == SLJIT_SUCCESS && wbuf[13] != (sljit_sw)(ibuf + 2), "test60 case 17 failed\n");
+	SLJIT_TEST_FAILED(supported[8] == SLJIT_SUCCESS && wbuf[14] != -887766, "test60 case 18 failed\n");
+	SLJIT_TEST_FAILED(supported[8] == SLJIT_SUCCESS && wbuf[15] != (sljit_sw)(wbuf + 10), "test60 case 19 failed\n");
+	SLJIT_TEST_FAILED(supported[9] == SLJIT_SUCCESS && wbuf[16] != -13, "test60 case 20 failed\n");
+	SLJIT_TEST_FAILED(supported[9] == SLJIT_SUCCESS && wbuf[17] != (sljit_sw)(bbuf), "test60 case 21 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test61(void)
+static SLJIT_TEST_FUNC test61(void *p)
 {
 	/* Test float memory accesses with pre/post updates. */
 	executable_code code;
@@ -6038,10 +6043,9 @@ static void test61(void)
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
 			printf("no fpu available, test61 skipped\n");
-		successful_tests++;
 		if (compiler)
 			sljit_free_compiler(compiler);
-		return;
+		SLJIT_TEST_SUCCEEDED();
 	}
 
 	if (verbose)
@@ -6060,7 +6064,7 @@ static void test61(void)
 	sbuf[2] = 0.0;
 	sbuf[3] = 0.0;
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), 4, 3, 4, 0, sizeof(sljit_sw));
 
@@ -6131,40 +6135,40 @@ static void test61(void)
 
 	code.func3((sljit_sw)&wbuf, (sljit_sw)&dbuf, (sljit_sw)&sbuf);
 
-	FAILED(sizeof(expected) != sizeof(supported) / sizeof(sljit_s32), "test61 case 1 failed\n");
+	SLJIT_TEST_FAILED(sizeof(expected) != sizeof(supported) / sizeof(sljit_s32), "test61 case 1 failed\n");
 
 	for (i = 0; i < sizeof(expected); i++) {
 		if (expected[i]) {
 			if (supported[i] != SLJIT_SUCCESS) {
 				printf("tast61 case %d should be supported\n", i + 1);
-				return;
+				SLJIT_TEST_RETURN(0);
 			}
 		} else {
 			if (supported[i] == SLJIT_SUCCESS) {
 				printf("test61 case %d should not be supported\n", i + 1);
-				return;
+				SLJIT_TEST_RETURN(0);
 			}
 		}
 	}
 
-	FAILED(supported[0] == SLJIT_SUCCESS && dbuf[1] != 66.725, "test61 case 2 failed\n");
-	FAILED(supported[0] == SLJIT_SUCCESS && wbuf[0] != (sljit_sw)(dbuf), "test61 case 3 failed\n");
-	FAILED(supported[1] == SLJIT_SUCCESS && dbuf[2] != 66.725, "test61 case 4 failed\n");
-	FAILED(supported[1] == SLJIT_SUCCESS && wbuf[1] != (sljit_sw)(dbuf + 1), "test61 case 5 failed\n");
-	FAILED(supported[2] == SLJIT_SUCCESS && sbuf[0] != -22.125, "test61 case 6 failed\n");
-	FAILED(supported[2] == SLJIT_SUCCESS && wbuf[2] != (sljit_sw)(sbuf), "test61 case 7 failed\n");
-	FAILED(supported[3] == SLJIT_SUCCESS && sbuf[2] != -22.125, "test61 case 8 failed\n");
-	FAILED(supported[3] == SLJIT_SUCCESS && wbuf[3] != (sljit_sw)(sbuf + 2), "test61 case 9 failed\n");
-	FAILED(supported[4] == SLJIT_SUCCESS && dbuf[3] != 66.725, "test61 case 10 failed\n");
-	FAILED(supported[4] == SLJIT_SUCCESS && wbuf[4] != (sljit_sw)(dbuf), "test61 case 11 failed\n");
-	FAILED(supported[5] == SLJIT_SUCCESS && sbuf[3] != -22.125, "test61 case 12 failed\n");
-	FAILED(supported[5] == SLJIT_SUCCESS && wbuf[5] != (sljit_sw)(sbuf + 3), "test61 case 13 failed\n");
+	SLJIT_TEST_FAILED(supported[0] == SLJIT_SUCCESS && dbuf[1] != 66.725, "test61 case 2 failed\n");
+	SLJIT_TEST_FAILED(supported[0] == SLJIT_SUCCESS && wbuf[0] != (sljit_sw)(dbuf), "test61 case 3 failed\n");
+	SLJIT_TEST_FAILED(supported[1] == SLJIT_SUCCESS && dbuf[2] != 66.725, "test61 case 4 failed\n");
+	SLJIT_TEST_FAILED(supported[1] == SLJIT_SUCCESS && wbuf[1] != (sljit_sw)(dbuf + 1), "test61 case 5 failed\n");
+	SLJIT_TEST_FAILED(supported[2] == SLJIT_SUCCESS && sbuf[0] != -22.125, "test61 case 6 failed\n");
+	SLJIT_TEST_FAILED(supported[2] == SLJIT_SUCCESS && wbuf[2] != (sljit_sw)(sbuf), "test61 case 7 failed\n");
+	SLJIT_TEST_FAILED(supported[3] == SLJIT_SUCCESS && sbuf[2] != -22.125, "test61 case 8 failed\n");
+	SLJIT_TEST_FAILED(supported[3] == SLJIT_SUCCESS && wbuf[3] != (sljit_sw)(sbuf + 2), "test61 case 9 failed\n");
+	SLJIT_TEST_FAILED(supported[4] == SLJIT_SUCCESS && dbuf[3] != 66.725, "test61 case 10 failed\n");
+	SLJIT_TEST_FAILED(supported[4] == SLJIT_SUCCESS && wbuf[4] != (sljit_sw)(dbuf), "test61 case 11 failed\n");
+	SLJIT_TEST_FAILED(supported[5] == SLJIT_SUCCESS && sbuf[3] != -22.125, "test61 case 12 failed\n");
+	SLJIT_TEST_FAILED(supported[5] == SLJIT_SUCCESS && wbuf[5] != (sljit_sw)(sbuf + 3), "test61 case 13 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test62(void)
+static SLJIT_TEST_FUNC test62(void *p)
 {
 	/* Test fast calls flag preservation. */
 	executable_code code1;
@@ -6176,7 +6180,7 @@ static void test62(void)
 
 	/* A */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	sljit_set_context(compiler, 0, SLJIT_ARG1(SW), 1, 1, 0, 0, 0);
 
 	sljit_emit_fast_enter(compiler, SLJIT_R0, 0);
@@ -6189,7 +6193,7 @@ static void test62(void)
 
 	/* B */
 	compiler = sljit_create_compiler(NULL);
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW), 1, 1, 0, 0, 0);
 	sljit_emit_ijump(compiler, SLJIT_FAST_CALL, SLJIT_IMM, SLJIT_FUNC_OFFSET(code1.code));
@@ -6204,16 +6208,16 @@ static void test62(void)
 	CHECK(compiler);
 	sljit_free_compiler(compiler);
 
-	FAILED(code2.func1(88) != 0, "test62 case 1 failed\n");
-	FAILED(code2.func1(42) != 1, "test62 case 2 failed\n");
-	FAILED(code2.func1(0)  != 2, "test62 case 3 failed\n");
+	SLJIT_TEST_FAILED(code2.func1(88) != 0, "test62 case 1 failed\n");
+	SLJIT_TEST_FAILED(code2.func1(42) != 1, "test62 case 2 failed\n");
+	SLJIT_TEST_FAILED(code2.func1(0)  != 2, "test62 case 3 failed\n");
 
 	sljit_free_code(code1.code);
 	sljit_free_code(code2.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test63(void)
+static SLJIT_TEST_FUNC test63(void *p)
 {
 	/* Test put label. */
 	executable_code code;
@@ -6231,7 +6235,7 @@ static void test63(void)
 	if (verbose)
 		printf("Run test63\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -6271,17 +6275,17 @@ static void test63(void)
 
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func1((sljit_sw)&buf) != addr[0], "test63 case 1 failed\n");
-	FAILED(buf[0] != addr[0], "test63 case 2 failed\n");
-	FAILED(buf[1] != addr[0], "test63 case 3 failed\n");
-	FAILED(buf[2] != addr[1], "test63 case 4 failed\n");
-	FAILED(buf[3] != addr[1], "test63 case 5 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != addr[0], "test63 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != addr[0], "test63 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != addr[0], "test63 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != addr[1], "test63 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != addr[1], "test63 case 5 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test64(void)
+static SLJIT_TEST_FUNC test64(void *p)
 {
 	/* Test put label with false labels (small offsets).
 	   This code is allocator implementation dependent. */
@@ -6306,7 +6310,7 @@ static void test64(void)
 
 	if (malloc_addr == 0) {
 		printf("Cannot allocate executable memory.");
-		return;
+		SLJIT_TEST_RETURN(0);
 	}
 
 	malloc_addr += SLJIT_EXEC_OFFSET((void*)malloc_addr);
@@ -6327,7 +6331,7 @@ static void test64(void)
 
 	compiler = sljit_create_compiler(NULL);
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 	buf[0] = 0;
 	buf[1] = 0;
 	buf[2] = 0;
@@ -6370,22 +6374,22 @@ static void test64(void)
 	/* WX allocator may not reuse the address. */
 	if ((sljit_sw)code.code < malloc_addr || (sljit_sw)code.code >= malloc_addr + 1024) {
 		printf("test64 executable alloc estimation failed\n");
-		return;
+		SLJIT_TEST_RETURN(0);
 	}
 #endif
 
-	FAILED(code.func1((sljit_sw)&buf) != label[3].addr, "test64 case 1 failed\n");
-	FAILED(buf[0] != label[0].addr, "test64 case 2 failed\n");
-	FAILED(buf[1] != label[0].addr, "test64 case 3 failed\n");
-	FAILED(buf[2] != label[1].addr, "test64 case 4 failed\n");
-	FAILED(buf[3] != label[1].addr, "test64 case 5 failed\n");
-	FAILED(buf[4] != label[2].addr, "test64 case 6 failed\n");
+	SLJIT_TEST_FAILED(code.func1((sljit_sw)&buf) != label[3].addr, "test64 case 1 failed\n");
+	SLJIT_TEST_FAILED(buf[0] != label[0].addr, "test64 case 2 failed\n");
+	SLJIT_TEST_FAILED(buf[1] != label[0].addr, "test64 case 3 failed\n");
+	SLJIT_TEST_FAILED(buf[2] != label[1].addr, "test64 case 4 failed\n");
+	SLJIT_TEST_FAILED(buf[3] != label[1].addr, "test64 case 5 failed\n");
+	SLJIT_TEST_FAILED(buf[4] != label[2].addr, "test64 case 6 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test65(void)
+static SLJIT_TEST_FUNC test65(void *p)
 {
 	/* Test jump tables. */
 	executable_code code;
@@ -6399,7 +6403,7 @@ static void test65(void)
 	if (verbose)
 		printf("Run test65\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 1, 2, 0, 0, 0);
 
@@ -6426,17 +6430,17 @@ static void test65(void)
 
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func2(64, 0) != -1, "test65 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func2(64, 0) != -1, "test65 case 1 failed\n");
 
 	for (i = 0; i < 64; i++) {
-		FAILED(code.func2(i, i * 2) != i * 4, "test65 case 2 failed\n");
+		SLJIT_TEST_FAILED(code.func2(i, i * 2) != i * 4, "test65 case 2 failed\n");
 	}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test66(void)
+static SLJIT_TEST_FUNC test66(void *p)
 {
 	/* Test direct jumps (computed goto). */
 	executable_code code;
@@ -6448,7 +6452,7 @@ static void test66(void)
 	if (verbose)
 		printf("Run test66\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), 1, 2, 0, 0, 0);
 	sljit_emit_ijump(compiler, SLJIT_JUMP, SLJIT_S0, 0);
@@ -6470,14 +6474,14 @@ static void test66(void)
 	sljit_free_compiler(compiler);
 
 	for (i = 0; i < 64; i++) {
-		FAILED(code.func2(addr[i], i) != i * 3, "test66 case 1 failed\n");
+		SLJIT_TEST_FAILED(code.func2(addr[i], i) != i * 3, "test66 case 1 failed\n");
 	}
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test67(void)
+static SLJIT_TEST_FUNC test67(void *p)
 {
 	/* Test skipping returns from fast calls (return type is fast). */
 	executable_code code;
@@ -6488,7 +6492,7 @@ static void test67(void)
 	if (verbose)
 		printf("Run test67\n");
 
-	FAILED(!compiler, "cannot create compiler\n");
+	SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 	sljit_emit_enter(compiler, 0, 0, 3, 1, 0, 0, 0);
 
@@ -6530,13 +6534,13 @@ static void test67(void)
 
 	sljit_free_compiler(compiler);
 
-	FAILED(code.func0() != 3, "test67 case 1 failed\n");
+	SLJIT_TEST_FAILED(code.func0() != 3, "test67 case 1 failed\n");
 
 	sljit_free_code(code.code);
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
-static void test68(void)
+static SLJIT_TEST_FUNC test68(void *p)
 {
 	/* Test skipping returns from fast calls (return type is normal). */
 	executable_code code;
@@ -6550,7 +6554,7 @@ static void test68(void)
 
 	for (i = 0; i < 6 * 2; i++) {
 		compiler = sljit_create_compiler(NULL);
-		FAILED(!compiler, "cannot create compiler\n");
+		SLJIT_TEST_FAILED(!compiler, "cannot create compiler\n");
 
 		sljit_emit_enter(compiler, (i >= 6 ? SLJIT_F64_ALIGNMENT : 0), 0, 2 + (i % 6), (i % 6), 0, 0, 0);
 
@@ -6582,12 +6586,12 @@ static void test68(void)
 
 		if (SLJIT_UNLIKELY(code.func0() != 4)) {
 			printf("test68 case %d failed\n", i + 1);
-			return;
+			SLJIT_TEST_RETURN(0);
 		}
 		sljit_free_code(code.code);
 	}
 
-	successful_tests++;
+	SLJIT_TEST_SUCCEEDED();
 }
 
 int sljit_test(int argc, char* argv[])
@@ -6600,76 +6604,76 @@ int sljit_test(int argc, char* argv[])
 		printf("Pass -v to enable verbose, -s to disable this hint.\n\n");
 
 #if !(defined SLJIT_CONFIG_UNSUPPORTED && SLJIT_CONFIG_UNSUPPORTED)
-	test_exec_allocator();
+	test_exec_allocator(NULL);
 #endif
-	test1();
-	test2();
-	test3();
-	test4();
-	test5();
-	test6();
-	test7();
-	test8();
-	test9();
-	test10();
-	test11();
-	test12();
-	test13();
-	test14();
-	test15();
-	test16();
-	test17();
-	test18();
-	test19();
-	test20();
-	test21();
-	test22();
-	test23();
-	test24();
-	test25();
-	test26();
-	test27();
-	test28();
-	test29();
-	test30();
-	test31();
-	test32();
-	test33();
-	test34();
-	test35();
-	test36();
-	test37();
-	test38();
-	test39();
-	test40();
-	test41();
-	test42();
-	test43();
-	test44();
-	test45();
-	test46();
-	test47();
-	test48();
-	test49();
-	test50();
-	test51();
-	test52();
-	test53();
-	test54();
-	test55();
-	test56();
-	test57();
-	test58();
-	test59();
-	test60();
-	test61();
-	test62();
-	test63();
-	test64();
-	test65();
-	test66();
-	test67();
-	test68();
+	SLJIT_TEST(test1(NULL));
+	SLJIT_TEST(test2(NULL));
+	SLJIT_TEST(test3(NULL));
+	SLJIT_TEST(test4(NULL));
+	SLJIT_TEST(test5(NULL));
+	SLJIT_TEST(test6(NULL));
+	SLJIT_TEST(test7(NULL));
+	SLJIT_TEST(test8(NULL));
+	SLJIT_TEST(test9(NULL));
+	SLJIT_TEST(test10(NULL));
+	SLJIT_TEST(test11(NULL));
+	SLJIT_TEST(test12(NULL));
+	SLJIT_TEST(test13(NULL));
+	SLJIT_TEST(test14(NULL));
+	SLJIT_TEST(test15(NULL));
+	SLJIT_TEST(test16(NULL));
+	SLJIT_TEST(test17(NULL));
+	SLJIT_TEST(test18(NULL));
+	SLJIT_TEST(test19(NULL));
+	SLJIT_TEST(test20(NULL));
+	SLJIT_TEST(test21(NULL));
+	SLJIT_TEST(test22(NULL));
+	SLJIT_TEST(test23(NULL));
+	SLJIT_TEST(test24(NULL));
+	SLJIT_TEST(test25(NULL));
+	SLJIT_TEST(test26(NULL));
+	SLJIT_TEST(test27(NULL));
+	SLJIT_TEST(test28(NULL));
+	SLJIT_TEST(test29(NULL));
+	SLJIT_TEST(test30(NULL));
+	SLJIT_TEST(test31(NULL));
+	SLJIT_TEST(test32(NULL));
+	SLJIT_TEST(test33(NULL));
+	SLJIT_TEST(test34(NULL));
+	SLJIT_TEST(test35(NULL));
+	SLJIT_TEST(test36(NULL));
+	SLJIT_TEST(test37(NULL));
+	SLJIT_TEST(test38(NULL));
+	SLJIT_TEST(test39(NULL));
+	SLJIT_TEST(test40(NULL));
+	SLJIT_TEST(test41(NULL));
+	SLJIT_TEST(test42(NULL));
+	SLJIT_TEST(test43(NULL));
+	SLJIT_TEST(test44(NULL));
+	SLJIT_TEST(test45(NULL));
+	SLJIT_TEST(test46(NULL));
+	SLJIT_TEST(test47(NULL));
+	SLJIT_TEST(test48(NULL));
+	SLJIT_TEST(test49(NULL));
+	SLJIT_TEST(test50(NULL));
+	SLJIT_TEST(test51(NULL));
+	SLJIT_TEST(test52(NULL));
+	SLJIT_TEST(test53(NULL));
+	SLJIT_TEST(test54(NULL));
+	SLJIT_TEST(test55(NULL));
+	SLJIT_TEST(test56(NULL));
+	SLJIT_TEST(test57(NULL));
+	SLJIT_TEST(test58(NULL));
+	SLJIT_TEST(test59(NULL));
+	SLJIT_TEST(test60(NULL));
+	SLJIT_TEST(test61(NULL));
+	SLJIT_TEST(test62(NULL));
+	SLJIT_TEST(test63(NULL));
+	SLJIT_TEST(test64(NULL));
+	SLJIT_TEST(test65(NULL));
+	SLJIT_TEST(test66(NULL));
+	SLJIT_TEST(test67(NULL));
+	SLJIT_TEST(test68(NULL));
 
 #if (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
 	sljit_free_unused_memory_exec();


### PR DESCRIPTION
Adds support for creating worker threads to run the tests using threads in parallel, so threading issues like the one in #76 are easier to find and fix.

This is more of a POC, and it is specifically aimed at stress testing the library to try to find issues when threading is enabled, not to run the tests faster.

as described in the third commit #70 is one of them, so if nothing at least this would help reproduce this in systems other than OpenBSD and even with the default allocator. 