### PR TITLE
Revert "Replace SLJIT_MIPS_R1 and SLJIT_MIPS_R6 macros into a single SLJIT_MIPS_REV macro."

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -487,25 +487,6 @@ typedef double sljit_f64;
 #define SLJIT_BIG_ENDIAN 1
 #endif
 
-#ifndef SLJIT_MIPS_REV
-
-/* Auto detecting mips revision. */
-#if (defined __mips_isa_rev) && (__mips_isa_rev >= 6)
-#define SLJIT_MIPS_REV 6
-#elif (defined __mips_isa_rev && __mips_isa_rev >= 1) \
-	|| (defined __clang__ && defined _MIPS_ARCH_OCTEON) \
-	|| (defined __clang__ && defined _MIPS_ARCH_P5600)
-/* clang either forgets to define (clang-7) __mips_isa_rev at all
- * or sets it to zero (clang-8,-9) for -march=octeon (MIPS64 R2+)
- * and -march=p5600 (MIPS32 R5).
- * It also sets the __mips macro to 64 or 32 for -mipsN when N <= 5
- * (should be set to N exactly) so we cannot rely on this too.
- */
-#define SLJIT_MIPS_REV 1
-#endif
-
-#endif /* !SLJIT_MIPS_REV */
-
 #elif (defined SLJIT_CONFIG_SPARC_32 && SLJIT_CONFIG_SPARC_32)
 
 #define SLJIT_BIG_ENDIAN 1

--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -2039,7 +2039,7 @@ static SLJIT_INLINE sljit_s32 emit_mov_before_return(struct sljit_compiler *comp
 #if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86) \
 		|| (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC) \
 		|| (defined SLJIT_CONFIG_SPARC_32 && SLJIT_CONFIG_SPARC_32) \
-		|| ((defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS) && !(defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1))
+		|| ((defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS) && !(defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1))
 
 static SLJIT_INLINE sljit_s32 sljit_emit_cmov_generic(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 dst_reg,

--- a/sljit_src/sljitNativeMIPS_32.c
+++ b/sljit_src/sljitNativeMIPS_32.c
@@ -86,12 +86,12 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE)) {
 			if (op == SLJIT_MOV_S8) {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 				return push_inst(compiler, SEB | T(src2) | D(dst), DR(dst));
-#else /* SLJIT_MIPS_REV < 1 */
+#else
 				FAIL_IF(push_inst(compiler, SLL | T(src2) | D(dst) | SH_IMM(24), DR(dst)));
 				return push_inst(compiler, SRA | T(dst) | D(dst) | SH_IMM(24), DR(dst));
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 			}
 			return push_inst(compiler, ANDI | S(src2) | T(dst) | IMM(0xff), DR(dst));
 		}
@@ -105,12 +105,12 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
 		if ((flags & (REG_DEST | REG2_SOURCE)) == (REG_DEST | REG2_SOURCE)) {
 			if (op == SLJIT_MOV_S16) {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 				return push_inst(compiler, SEH | T(src2) | D(dst), DR(dst));
-#else /* SLJIT_MIPS_REV < 1 */
+#else
 				FAIL_IF(push_inst(compiler, SLL | T(src2) | D(dst) | SH_IMM(16), DR(dst)));
 				return push_inst(compiler, SRA | T(dst) | D(dst) | SH_IMM(16), DR(dst));
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 			}
 			return push_inst(compiler, ANDI | S(src2) | T(dst) | IMM(0xffff), DR(dst));
 		}
@@ -129,12 +129,12 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 
 	case SLJIT_CLZ:
 		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 		if (op & SLJIT_SET_Z)
 			FAIL_IF(push_inst(compiler, CLZ | S(src2) | TA(EQUAL_FLAG) | DA(EQUAL_FLAG), EQUAL_FLAG));
 		if (!(flags & UNUSED_DEST))
 			FAIL_IF(push_inst(compiler, CLZ | S(src2) | T(dst) | D(dst), DR(dst)));
-#else /* SLJIT_MIPS_REV < 1 */
+#else
 		if (SLJIT_UNLIKELY(flags & UNUSED_DEST)) {
 			FAIL_IF(push_inst(compiler, SRL | T(src2) | DA(EQUAL_FLAG) | SH_IMM(31), EQUAL_FLAG));
 			return push_inst(compiler, XORI | SA(EQUAL_FLAG) | TA(EQUAL_FLAG) | IMM(1), EQUAL_FLAG);
@@ -149,7 +149,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		FAIL_IF(push_inst(compiler, ADDIU | S(dst) | T(dst) | IMM(1), DR(dst)));
 		FAIL_IF(push_inst(compiler, BGEZ | S(TMP_REG1) | IMM(-2), UNMOVABLE_INS));
 		FAIL_IF(push_inst(compiler, SLL | T(TMP_REG1) | D(TMP_REG1) | SH_IMM(1), UNMOVABLE_INS));
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 		return SLJIT_SUCCESS;
 
 	case SLJIT_ADD:
@@ -368,22 +368,21 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		SLJIT_ASSERT(!(flags & SRC2_IMM));
 
 		if (GET_FLAG_TYPE(op) != SLJIT_MUL_OVERFLOW) {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1) || (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 			return push_inst(compiler, MUL | S(src1) | T(src2) | D(dst), DR(dst));
-#else /* SLJIT_MIPS_REV < 1 */
+#else /* !SLJIT_MIPS_R1 && !SLJIT_MIPS_R6 */
 			FAIL_IF(push_inst(compiler, MULT | S(src1) | T(src2), MOVABLE_INS));
 			return push_inst(compiler, MFLO | D(dst), DR(dst));
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif /* SLJIT_MIPS_R1 || SLJIT_MIPS_R6 */
 		}
-
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 		FAIL_IF(push_inst(compiler, MUL | S(src1) | T(src2) | D(dst), DR(dst)));
 		FAIL_IF(push_inst(compiler, MUH | S(src1) | T(src2) | DA(EQUAL_FLAG), EQUAL_FLAG));
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, MULT | S(src1) | T(src2), MOVABLE_INS));
 		FAIL_IF(push_inst(compiler, MFHI | DA(EQUAL_FLAG), EQUAL_FLAG));
 		FAIL_IF(push_inst(compiler, MFLO | D(dst), DR(dst)));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, SRA | T(dst) | DA(OTHER_FLAG) | SH_IMM(31), OTHER_FLAG));
 		return push_inst(compiler, SUBU | SA(EQUAL_FLAG) | TA(OTHER_FLAG) | DA(OTHER_FLAG), OTHER_FLAG);
 

--- a/sljit_src/sljitNativeMIPS_64.c
+++ b/sljit_src/sljitNativeMIPS_64.c
@@ -220,12 +220,12 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 
 	case SLJIT_CLZ:
 		SLJIT_ASSERT(src1 == TMP_REG1 && !(flags & SRC2_IMM));
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 		if (op & SLJIT_SET_Z)
 			FAIL_IF(push_inst(compiler, SELECT_OP(DCLZ, CLZ) | S(src2) | TA(EQUAL_FLAG) | DA(EQUAL_FLAG), EQUAL_FLAG));
 		if (!(flags & UNUSED_DEST))
 			FAIL_IF(push_inst(compiler, SELECT_OP(DCLZ, CLZ) | S(src2) | T(dst) | D(dst), DR(dst)));
-#else /* SLJIT_MIPS_REV < 1 */
+#else
 		if (SLJIT_UNLIKELY(flags & UNUSED_DEST)) {
 			FAIL_IF(push_inst(compiler, SELECT_OP(DSRL32, SRL) | T(src2) | DA(EQUAL_FLAG) | SH_IMM(31), EQUAL_FLAG));
 			return push_inst(compiler, XORI | SA(EQUAL_FLAG) | TA(EQUAL_FLAG) | IMM(1), EQUAL_FLAG);
@@ -240,7 +240,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		FAIL_IF(push_inst(compiler, SELECT_OP(DADDIU, ADDIU) | S(dst) | T(dst) | IMM(1), DR(dst)));
 		FAIL_IF(push_inst(compiler, BGEZ | S(TMP_REG1) | IMM(-2), UNMOVABLE_INS));
 		FAIL_IF(push_inst(compiler, SELECT_OP(DSLL, SLL) | T(TMP_REG1) | D(TMP_REG1) | SH_IMM(1), UNMOVABLE_INS));
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 		return SLJIT_SUCCESS;
 
 	case SLJIT_ADD:
@@ -459,27 +459,26 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		SLJIT_ASSERT(!(flags & SRC2_IMM));
 
 		if (GET_FLAG_TYPE(op) != SLJIT_MUL_OVERFLOW) {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 			return push_inst(compiler, SELECT_OP(DMUL, MUL) | S(src1) | T(src2) | D(dst), DR(dst));
-#elif (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#elif (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 			if (op & SLJIT_I32_OP)
 				return push_inst(compiler, MUL | S(src1) | T(src2) | D(dst), DR(dst));
 			FAIL_IF(push_inst(compiler, DMULT | S(src1) | T(src2), MOVABLE_INS));
 			return push_inst(compiler, MFLO | D(dst), DR(dst));
-#else /* SLJIT_MIPS_REV < 1 */
+#else /* !SLJIT_MIPS_R6 && !SLJIT_MIPS_R1 */
 			FAIL_IF(push_inst(compiler, SELECT_OP(DMULT, MULT) | S(src1) | T(src2), MOVABLE_INS));
 			return push_inst(compiler, MFLO | D(dst), DR(dst));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 		}
-
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 		FAIL_IF(push_inst(compiler, SELECT_OP(DMUL, MUL) | S(src1) | T(src2) | D(dst), DR(dst)));
 		FAIL_IF(push_inst(compiler, SELECT_OP(DMUH, MUH) | S(src1) | T(src2) | DA(EQUAL_FLAG), EQUAL_FLAG));
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, SELECT_OP(DMULT, MULT) | S(src1) | T(src2), MOVABLE_INS));
 		FAIL_IF(push_inst(compiler, MFHI | DA(EQUAL_FLAG), EQUAL_FLAG));
 		FAIL_IF(push_inst(compiler, MFLO | D(dst), DR(dst)));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, SELECT_OP(DSRA32, SRA) | T(dst) | DA(OTHER_FLAG) | SH_IMM(31), OTHER_FLAG));
 		return push_inst(compiler, SELECT_OP(DSUBU, SUBU) | SA(EQUAL_FLAG) | TA(OTHER_FLAG) | DA(OTHER_FLAG), OTHER_FLAG);
 

--- a/sljit_src/sljitNativeMIPS_common.c
+++ b/sljit_src/sljitNativeMIPS_common.c
@@ -25,16 +25,15 @@
  */
 
 /* Latest MIPS architecture. */
+/* Automatically detect SLJIT_MIPS_R1 */
 
-#ifndef __mips_hard_float
-/* Disable automatic detection, covers both -msoft-float and -mno-float */
-#undef SLJIT_IS_FPU_AVAILABLE
-#define SLJIT_IS_FPU_AVAILABLE 0
+#if (defined __mips_isa_rev) && (__mips_isa_rev >= 6)
+#define SLJIT_MIPS_R6 1
 #endif
 
 SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
 	return "MIPS32-R6" SLJIT_CPUINFO;
@@ -42,7 +41,7 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 	return "MIPS64-R6" SLJIT_CPUINFO;
 #endif /* SLJIT_CONFIG_MIPS_32 */
 
-#elif (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#elif (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
 	return "MIPS32-R1" SLJIT_CPUINFO;
@@ -50,9 +49,9 @@ SLJIT_API_FUNC_ATTRIBUTE const char* sljit_get_platform_name(void)
 	return "MIPS64-R1" SLJIT_CPUINFO;
 #endif /* SLJIT_CONFIG_MIPS_32 */
 
-#else /* SLJIT_MIPS_REV < 1 */
+#else /* SLJIT_MIPS_R1 */
 	return "MIPS III" SLJIT_CPUINFO;
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 }
 
 /* Length of an instruction word
@@ -118,11 +117,11 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define FR(dr)		(freg_map[dr])
 #define HI(opcode)	((opcode) << 26)
 #define LO(opcode)	(opcode)
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 /* CMP.cond.fmt */
 /* S = (20 << 21) D = (21 << 21) */
 #define CMP_FMT_S	(20 << 21)
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 /* S = (16 << 21) D = (17 << 21) */
 #define FMT_S		(16 << 21)
 #define FMT_D		(17 << 21)
@@ -135,13 +134,13 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define ANDI		(HI(12))
 #define B		(HI(4))
 #define BAL		(HI(1) | (17 << 16))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define BC1EQZ		(HI(17) | (9 << 21) | FT(TMP_FREG3))
 #define BC1NEZ		(HI(17) | (13 << 21) | FT(TMP_FREG3))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define BC1F		(HI(17) | (8 << 21))
 #define BC1T		(HI(17) | (8 << 21) | (1 << 16))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define BEQ		(HI(4))
 #define BGEZ		(HI(1) | (1 << 16))
 #define BGTZ		(HI(7))
@@ -150,23 +149,23 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define BNE		(HI(5))
 #define BREAK		(HI(0) | LO(13))
 #define CFC1		(HI(17) | (2 << 21))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define C_UEQ_S		(HI(17) | CMP_FMT_S | LO(3))
 #define C_ULE_S		(HI(17) | CMP_FMT_S | LO(7))
 #define C_ULT_S		(HI(17) | CMP_FMT_S | LO(5))
 #define C_UN_S		(HI(17) | CMP_FMT_S | LO(1))
 #define C_FD		(FD(TMP_FREG3))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define C_UEQ_S		(HI(17) | FMT_S | LO(51))
 #define C_ULE_S		(HI(17) | FMT_S | LO(55))
 #define C_ULT_S		(HI(17) | FMT_S | LO(53))
 #define C_UN_S		(HI(17) | FMT_S | LO(49))
 #define C_FD		(0)
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define CVT_S_S		(HI(17) | FMT_S | LO(32))
 #define DADDIU		(HI(25))
 #define DADDU		(HI(0) | LO(45))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define DDIV		(HI(0) | (2 << 6) | LO(30))
 #define DDIVU		(HI(0) | (2 << 6) | LO(31))
 #define DMOD		(HI(0) | (3 << 6) | LO(30))
@@ -177,14 +176,14 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define DMUHU		(HI(0) | (3 << 6) | LO(29))
 #define DMUL		(HI(0) | (2 << 6) | LO(28))
 #define DMULU		(HI(0) | (2 << 6) | LO(29))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define DDIV		(HI(0) | LO(30))
 #define DDIVU		(HI(0) | LO(31))
 #define DIV		(HI(0) | LO(26))
 #define DIVU		(HI(0) | LO(27))
 #define DMULT		(HI(0) | LO(28))
 #define DMULTU		(HI(0) | LO(29))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define DIV_S		(HI(17) | FMT_S | LO(3))
 #define DSLL		(HI(0) | LO(56))
 #define DSLL32		(HI(0) | LO(60))
@@ -199,33 +198,33 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define J		(HI(2))
 #define JAL		(HI(3))
 #define JALR		(HI(0) | LO(9))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define JR		(HI(0) | LO(9))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define JR		(HI(0) | LO(8))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define LD		(HI(55))
 #define LUI		(HI(15))
 #define LW		(HI(35))
 #define MFC1		(HI(17))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
-#define MOD		(HI(0) | (3 << 6) | LO(26))
-#define MODU		(HI(0) | (3 << 6) | LO(27))
-#else /* SLJIT_MIPS_REV < 6 */
+#if !(defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define MFHI		(HI(0) | LO(16))
 #define MFLO		(HI(0) | LO(18))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#else /* SLJIT_MIPS_R6 */
+#define MOD		(HI(0) | (3 << 6) | LO(26))
+#define MODU		(HI(0) | (3 << 6) | LO(27))
+#endif /* !SLJIT_MIPS_R6 */
 #define MOV_S		(HI(17) | FMT_S | LO(6))
 #define MTC1		(HI(17) | (4 << 21))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define MUH		(HI(0) | (3 << 6) | LO(24))
 #define MUHU		(HI(0) | (3 << 6) | LO(25))
 #define MUL		(HI(0) | (2 << 6) | LO(24))
 #define MULU		(HI(0) | (2 << 6) | LO(25))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define MULT		(HI(0) | LO(24))
 #define MULTU		(HI(0) | LO(25))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define MUL_S		(HI(17) | FMT_S | LO(2))
 #define NEG_S		(HI(17) | FMT_S | LO(7))
 #define NOP		(HI(0) | LO(0))
@@ -252,23 +251,23 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define XOR		(HI(0) | LO(38))
 #define XORI		(HI(14))
 
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1) || (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define CLZ		(HI(28) | LO(32))
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #define DCLZ		(LO(18))
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #define DCLZ		(HI(28) | LO(36))
 #define MOVF		(HI(0) | (0 << 16) | LO(1))
 #define MOVN		(HI(0) | LO(11))
 #define MOVT		(HI(0) | (1 << 16) | LO(1))
 #define MOVZ		(HI(0) | LO(10))
 #define MUL		(HI(28) | LO(2))
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 #define PREF		(HI(51))
 #define PREFX		(HI(19) | LO(15))
 #define SEB		(HI(31) | (16 << 6) | LO(32))
 #define SEH		(HI(31) | (24 << 6) | LO(32))
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 
 #if (defined SLJIT_CONFIG_MIPS_32 && SLJIT_CONFIG_MIPS_32)
 #define ADDU_W		ADDU
@@ -304,10 +303,10 @@ static SLJIT_INLINE sljit_ins invert_branch(sljit_s32 flags)
 {
 	if (flags & IS_BIT26_COND)
 		return (1 << 26);
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 	if (flags & IS_BIT23_COND)
 		return (1 << 23);
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 	return (1 << 16);
 }
 
@@ -688,12 +687,12 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 	case SLJIT_HAS_ZERO_REGISTER:
 		return 1;
 
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 	case SLJIT_HAS_CLZ:
 	case SLJIT_HAS_CMOV:
 	case SLJIT_HAS_PREFETCH:
 		return 1;
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 
 	default:
 		return fir;
@@ -1235,7 +1234,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 		return push_inst(compiler, NOP, UNMOVABLE_INS);
 	case SLJIT_LMUL_UW:
 	case SLJIT_LMUL_SW:
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		FAIL_IF(push_inst(compiler, (op == SLJIT_LMUL_UW ? DMULU : DMUL) | S(SLJIT_R0) | T(SLJIT_R1) | D(TMP_REG3), DR(TMP_REG3)));
 		FAIL_IF(push_inst(compiler, (op == SLJIT_LMUL_UW ? DMUHU : DMUH) | S(SLJIT_R0) | T(SLJIT_R1) | D(TMP_REG1), DR(TMP_REG1)));
@@ -1245,7 +1244,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 #endif /* SLJIT_CONFIG_MIPS_64 */
 		FAIL_IF(push_inst(compiler, ADDU_W | S(TMP_REG3) | TA(0) | D(SLJIT_R0), DR(SLJIT_R0)));
 		return push_inst(compiler, ADDU_W | S(TMP_REG1) | TA(0) | D(SLJIT_R1), DR(SLJIT_R1));
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		FAIL_IF(push_inst(compiler, (op == SLJIT_LMUL_UW ? DMULTU : DMULT) | S(SLJIT_R0) | T(SLJIT_R1), MOVABLE_INS));
 #else /* !SLJIT_CONFIG_MIPS_64 */
@@ -1253,13 +1252,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 #endif /* SLJIT_CONFIG_MIPS_64 */
 		FAIL_IF(push_inst(compiler, MFLO | D(SLJIT_R0), DR(SLJIT_R0)));
 		return push_inst(compiler, MFHI | D(SLJIT_R1), DR(SLJIT_R1));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 	case SLJIT_DIVMOD_UW:
 	case SLJIT_DIVMOD_SW:
 	case SLJIT_DIV_UW:
 	case SLJIT_DIV_SW:
 		SLJIT_COMPILE_ASSERT((SLJIT_DIVMOD_UW & 0x2) == 0 && SLJIT_DIV_UW - 0x2 == SLJIT_DIVMOD_UW, bad_div_opcode_assignments);
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		if (int_op) {
 			FAIL_IF(push_inst(compiler, ((op | 0x2) == SLJIT_DIV_UW ? DIVU : DIV) | S(SLJIT_R0) | T(SLJIT_R1) | D(TMP_REG3), DR(TMP_REG3)));
@@ -1275,11 +1274,11 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 #endif /* SLJIT_CONFIG_MIPS_64 */
 		FAIL_IF(push_inst(compiler, ADDU_W | S(TMP_REG3) | TA(0) | D(SLJIT_R0), DR(SLJIT_R0)));
 		return (op >= SLJIT_DIV_UW) ? SLJIT_SUCCESS : push_inst(compiler, ADDU_W | S(TMP_REG1) | TA(0) | D(SLJIT_R1), DR(SLJIT_R1));
-#else /* SLJIT_MIPS_REV < 6 */
-#if !(defined SLJIT_MIPS_REV)
+#else /* !SLJIT_MIPS_R6 */
+#if !(defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 		FAIL_IF(push_inst(compiler, NOP, UNMOVABLE_INS));
 		FAIL_IF(push_inst(compiler, NOP, UNMOVABLE_INS));
-#endif /* !SLJIT_MIPS_REV */
+#endif /* !SLJIT_MIPS_R1 */
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		if (int_op)
 			FAIL_IF(push_inst(compiler, ((op | 0x2) == SLJIT_DIV_UW ? DIVU : DIV) | S(SLJIT_R0) | T(SLJIT_R1), MOVABLE_INS));
@@ -1290,7 +1289,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 #endif /* SLJIT_CONFIG_MIPS_64 */
 		FAIL_IF(push_inst(compiler, MFLO | D(SLJIT_R0), DR(SLJIT_R0)));
 		return (op >= SLJIT_DIV_UW) ? SLJIT_SUCCESS : push_inst(compiler, MFHI | D(SLJIT_R1), DR(SLJIT_R1));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_64 */
 	case SLJIT_ENDBR:
 	case SLJIT_SKIP_FRAMES_BEFORE_RETURN:
 		return SLJIT_SUCCESS;
@@ -1299,7 +1298,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 	return SLJIT_SUCCESS;
 }
 
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 static sljit_s32 emit_prefetch(struct sljit_compiler *compiler,
         sljit_s32 src, sljit_sw srcw)
 {
@@ -1320,7 +1319,7 @@ static sljit_s32 emit_prefetch(struct sljit_compiler *compiler,
 
 	return push_inst(compiler, PREFX | S(src & REG_MASK) | T(OFFS_REG(src)), MOVABLE_INS);
 }
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compiler, sljit_s32 op,
 	sljit_s32 dst, sljit_sw dstw,
@@ -1809,7 +1808,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_label* sljit_emit_label(struct sljit_compi
 	flags = IS_BIT26_COND; \
 	delay_check = src;
 
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 
 #define BR_T() \
 	inst = BC1NEZ; \
@@ -1820,7 +1819,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_label* sljit_emit_label(struct sljit_compi
 	flags = IS_BIT23_COND; \
 	delay_check = FCSR_FCC;
 
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 
 #define BR_T() \
 	inst = BC1T | JUMP_LENGTH; \
@@ -1831,7 +1830,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_label* sljit_emit_label(struct sljit_compi
 	flags = IS_BIT16_COND; \
 	delay_check = FCSR_FCC;
 
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 
 SLJIT_API_FUNC_ATTRIBUTE struct sljit_jump* sljit_emit_jump(struct sljit_compiler *compiler, sljit_s32 type)
 {
@@ -2142,11 +2141,11 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_flags(struct sljit_compiler *co
 	case SLJIT_GREATER_EQUAL_F64:
 	case SLJIT_UNORDERED_F64:
 	case SLJIT_ORDERED_F64:
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#if (defined SLJIT_MIPS_R6 && SLJIT_MIPS_R6)
 		FAIL_IF(push_inst(compiler, MFC1 | TA(dst_ar) | FS(TMP_FREG3), dst_ar));
-#else /* SLJIT_MIPS_REV < 6 */
+#else /* !SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, CFC1 | TA(dst_ar) | DA(FCSR_REG), dst_ar));
-#endif /* SLJIT_MIPS_REV >= 6 */
+#endif /* SLJIT_MIPS_R6 */
 		FAIL_IF(push_inst(compiler, SRL | TA(dst_ar) | DA(dst_ar) | SH_IMM(23), dst_ar));
 		FAIL_IF(push_inst(compiler, ANDI | SA(dst_ar) | TA(dst_ar) | IMM(1), dst_ar));
 		src_ar = dst_ar;
@@ -2186,14 +2185,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_cmov(struct sljit_compiler *compil
 	sljit_s32 dst_reg,
 	sljit_s32 src, sljit_sw srcw)
 {
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 	sljit_ins ins;
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_cmov(compiler, type, dst_reg, src, srcw));
 
-#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
+#if (defined SLJIT_MIPS_R1 && SLJIT_MIPS_R1)
 
 	if (SLJIT_UNLIKELY(src & SLJIT_IMM)) {
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
@@ -2250,9 +2249,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_cmov(struct sljit_compiler *compil
 
 	return push_inst(compiler, ins | S(src) | D(dst_reg), DR(dst_reg));
 
-#else /* SLJIT_MIPS_REV < 1 */
+#else
 	return sljit_emit_cmov_generic(compiler, type, dst_reg, src, srcw);
-#endif /* SLJIT_MIPS_REV >= 1 */
+#endif
 }
 
 SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compiler *compiler, sljit_s32 dst, sljit_sw dstw, sljit_sw init_value)


### PR DESCRIPTION
This reverts commit 08cb6251ded26e79b883543b9741575e84e172fb.

got the build going again and the test running with the correct ISA detected, but needs more review and testing.

some of the previous refactoring might be also worth reapplying

Fixes: #81 