### PR TITLE
Update configuration macros.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(BINDIR)/regexJIT.o : $(REGEXDIR)/regexJIT.c $(BINDIR)/.keep $(SLJIT_HEADERS) $
 	$(CC) $(CPPFLAGS) $(REGEX_CFLAGS) -c -o $@ $(REGEXDIR)/regexJIT.c
 
 $(BINDIR)/sljit_test: $(BINDIR)/.keep $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c $(SLJIT_LIR_FILES) $(SLJIT_HEADERS) $(TESTDIR)/sljitConfigPre.h $(TESTDIR)/sljitConfigPost.h
-	$(CC) $(CPPFLAGS) -DSLJIT_CUSTOM_CONFIG=1 -I$(TESTDIR) $(CFLAGS) $(LDFLAGS) $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c -o $@ -lm -lpthread
+	$(CC) $(CPPFLAGS) -DSLJIT_HAVE_CONFIG_PRE=1 -I$(TESTDIR) $(CFLAGS) $(LDFLAGS) $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c -o $@ -lm -lpthread
 
 $(BINDIR)/regex_test: $(BINDIR)/.keep $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o -o $@ -lm -lpthread

--- a/sljit_src/sljitConfig.h
+++ b/sljit_src/sljitConfig.h
@@ -31,12 +31,12 @@
 extern "C" {
 #endif
 
-/* --------------------------------------------------------------------- */
-/*  Custom defines                                                       */
-/* --------------------------------------------------------------------- */
-
-/* Put your custom defines here. This empty section will never change
-   which helps maintaining patches (with diff / patch utilities). */
+/*
+  This file contains the basic configuration options for the SLJIT compiler
+  and their default values. These options can be overridden in the
+  sljitConfigPre.h header file when SLJIT_HAVE_CONFIG_PRE is set to a
+  non-zero value.
+*/
 
 /* --------------------------------------------------------------------- */
 /*  Architecture                                                         */

--- a/sljit_src/sljitLir.h
+++ b/sljit_src/sljitLir.h
@@ -70,17 +70,11 @@
       - pass --smc-check=all argument to valgrind, since JIT is a "self-modifying code"
 */
 
-#if (defined SLJIT_CUSTOM_CONFIG && SLJIT_CUSTOM_CONFIG)
-#define SLJIT_HAVE_SLJIT_CONFIG_PRE_H 1
-#endif /* SLJIT_CUSTOM_CONFIG */
-
-#if (defined SLJIT_HAVE_SLJIT_CONFIG_PRE_H && SLJIT_HAVE_SLJIT_CONFIG_PRE_H)
+#if (defined SLJIT_HAVE_CONFIG_PRE && SLJIT_HAVE_CONFIG_PRE)
 #include "sljitConfigPre.h"
-#endif /* SLJIT_HAVE_SLJIT_CONFIG_PRE_H */
+#endif /* SLJIT_HAVE_CONFIG_PRE */
 
-#if !(defined SLJIT_NO_DEFAULT_CONFIG && SLJIT_NO_DEFAULT_CONFIG)
 #include "sljitConfig.h"
-#endif /* SLJIT_NO_DEFAULT_CONFIG */
 
 /* The following header file defines useful macros for fine tuning
 sljit based code generators. They are listed in the beginning
@@ -88,9 +82,9 @@ of sljitConfigInternal.h */
 
 #include "sljitConfigInternal.h"
 
-#if (defined SLJIT_HAVE_SLJIT_CONFIG_POST_H && SLJIT_HAVE_SLJIT_CONFIG_POST_H)
+#if (defined SLJIT_HAVE_CONFIG_POST && SLJIT_HAVE_CONFIG_POST)
 #include "sljitConfigPost.h"
-#endif /* SLJIT_HAVE_SLJIT_CONFIG_POST_H */
+#endif /* SLJIT_HAVE_CONFIG_POST */
 
 #ifdef __cplusplus
 extern "C" {

--- a/test_src/sljitConfigPre.h
+++ b/test_src/sljitConfigPre.h
@@ -27,7 +27,7 @@
 #ifndef SLJIT_CONFIG_PRE_H_
 #define SLJIT_CONFIG_PRE_H_
 
-#define SLJIT_HAVE_SLJIT_CONFIG_POST_H 1
+#define SLJIT_HAVE_CONFIG_POST 1
 
 #define SLJIT_MALLOC_EXEC(size, exec_allocator_data) sljit_test_malloc_exec((size), (exec_allocator_data))
 #define SLJIT_FREE_EXEC(ptr, exec_allocator_data) sljit_test_free_code((ptr), (exec_allocator_data))


### PR DESCRIPTION
Remove SLJIT_NO_DEFAULT_CONFIG and SLJIT_CUSTOM_CONFIG, and simplify
SLJIT_HAVE_SLJIT_CONFIG_PRE_H and SLJIT_HAVE_SLJIT_CONFIG_POST_H.