### PR TITLE
Fix SLJIT_FUNC calling convention in tutorial

### DIFF
--- a/doc/tutorial/array_access.c
+++ b/doc/tutorial/array_access.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func_arr_t)(long *arr, long narr);
+typedef long (SLJIT_FUNC *func_arr_t)(long *arr, long narr);
 
-static SLJIT_FUNC long print_num(long a)
+static long SLJIT_FUNC print_num(long a)
 {
 	printf("num = %ld\n", a);
 	return a + 1;

--- a/doc/tutorial/brainfuck.c
+++ b/doc/tutorial/brainfuck.c
@@ -111,22 +111,22 @@ static int loop_pop(struct sljit_label **loop_start, struct sljit_jump **loop_en
 	return 0;
 }
 
-static SLJIT_FUNC void *my_alloc(long size, long n)
+static void *SLJIT_FUNC my_alloc(long size, long n)
 {
 	return calloc(size, n);
 }
 
-static SLJIT_FUNC void my_putchar(long c)
+static void SLJIT_FUNC my_putchar(long c)
 {
 	putchar(c);
 }
 
-static SLJIT_FUNC long my_getchar(void)
+static long SLJIT_FUNC my_getchar(void)
 {
 	return getchar();
 }
 
-static SLJIT_FUNC void my_free(void *mem)
+static void SLJIT_FUNC my_free(void *mem)
 {
 	free(mem);
 }

--- a/doc/tutorial/brainfuck.c
+++ b/doc/tutorial/brainfuck.c
@@ -89,7 +89,7 @@ struct loop_node_st {
 static struct loop_node_st loop_stack[BF_LOOP_LEVEL];
 static int loop_sp;
 
-static SLJIT_FUNC int loop_push(struct sljit_label *loop_start, struct sljit_jump *loop_end)
+static int loop_push(struct sljit_label *loop_start, struct sljit_jump *loop_end)
 {
 	if (loop_sp >= BF_LOOP_LEVEL)
 		return -1;
@@ -100,7 +100,7 @@ static SLJIT_FUNC int loop_push(struct sljit_label *loop_start, struct sljit_jum
 	return 0;
 }
 
-static SLJIT_FUNC int loop_pop(struct sljit_label **loop_start, struct sljit_jump **loop_end)
+static int loop_pop(struct sljit_label **loop_start, struct sljit_jump **loop_end)
 {
 	if (loop_sp <= 0)
 		return -1;

--- a/doc/tutorial/branch.c
+++ b/doc/tutorial/branch.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func3_t)(long a, long b, long c);
+typedef long (SLJIT_FUNC *func3_t)(long a, long b, long c);
 
 /*
   This example, we generate a function like this:

--- a/doc/tutorial/first_program.c
+++ b/doc/tutorial/first_program.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func3_t)(long a, long b, long c);
+typedef long (SLJIT_FUNC *func3_t)(long a, long b, long c);
 
 static int add3(long a, long b, long c)
 {

--- a/doc/tutorial/func_call.c
+++ b/doc/tutorial/func_call.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func3_t)(long a, long b, long c);
+typedef long (SLJIT_FUNC *func3_t)(long a, long b, long c);
 
-static SLJIT_FUNC long print_num(long a)
+static long SLJIT_FUNC print_num(long a)
 {
 	printf("a = %ld\n", a);
 	return a + 1;

--- a/doc/tutorial/loop.c
+++ b/doc/tutorial/loop.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func2_t)(long a, long b);
+typedef long (SLJIT_FUNC *func2_t)(long a, long b);
 
 /*
   This example, we generate a function like this:

--- a/doc/tutorial/struct_access.c
+++ b/doc/tutorial/struct_access.c
@@ -10,9 +10,9 @@ struct point_st {
 	char d;
 };
 
-typedef SLJIT_FUNC long (*point_func_t)(struct point_st *point);;
+typedef long (SLJIT_FUNC *point_func_t)(struct point_st *point);;
 
-static SLJIT_FUNC long print_num(long a)
+static long SLJIT_FUNC print_num(long a)
 {
 	printf("a = %ld\n", a);
 	return a + 1;

--- a/doc/tutorial/temp_var.c
+++ b/doc/tutorial/temp_var.c
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef SLJIT_FUNC long (*func3_t)(long a, long b, long c);
+typedef long (SLJIT_FUNC *func3_t)(long a, long b, long c);
 
-static SLJIT_FUNC long print_arr(long *a, long n)
+static long SLJIT_FUNC print_arr(long *a, long n)
 {
 	long i;
 	long sum = 0;


### PR DESCRIPTION
The tutorial in `doc` folder is too old.
I just fixed them for **MSVC** 👍

```diff
-typedef SLJIT_FUNC (*func_t)();
-static SLJIT_FUNC int func() { ... }
        ^~~~~~~~~~ syntax error (on MSVC)
+typedef (SLJIT_FUNC *func_t)();
+static int SLJIT_FUNC func() { ... }
```