### PR TITLE
Fix initialization of the allocator_lock on Win32

### DIFF
--- a/sljit_src/sljitUtils.c
+++ b/sljit_src/sljitUtils.c
@@ -48,7 +48,7 @@ static HANDLE allocator_lock;
 static SLJIT_INLINE void allocator_grab_lock(void)
 {
 	HANDLE lock;
-	if (SLJIT_UNLIKELY(!allocator_lock)) {
+	if (SLJIT_UNLIKELY(!InterlockedCompareExchangePointer(&allocator_lock, NULL, NULL))) {
 		lock = CreateMutex(NULL, FALSE, NULL);
 		if (InterlockedCompareExchangePointer(&allocator_lock, lock, NULL))
 			CloseHandle(lock);


### PR DESCRIPTION
Fix two problems in one go:

- The read of `allocator_lock` is not atomic, and races against the write
  a few lines below. The Interlocked API docs clearly state [1]:

  > "This function is atomic with respect to calls to other interlocked
  > functions."

  A plain read is *not* atomic (see below).

- There is no read barrier to acquire the memory pointed by `allocator_lock`;
  therefore, the write barrier inserted by the Interlocked API a few lines
  below does not synchronize with a non-NULL read. (A non-NULL read may
  not find the memory pointed by `allocator_lock` committed yet.)

There are two possible solutions, a MSVC-specific one and a generic one.
MSVC-specific would be to mark `allocator_lock` as volatile. volatile
has almost nothing to do with atomicity and synchronization, except on
MSVC on non-ARM, where it is actually atomic and synchronizes [2].

A generic one is to use the Interlocked API for the read part as well,
so that we're not tied to MSVC and non-ARM.

This commit implements this last one.

[1] https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-interlockedcompareexchangepointer
[2] https://docs.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-160&viewFallbackFrom=vs-2019#end-of-iso-compliant