### PR TITLE
freebsd: add support for PROT_MAX (since 13)

### DIFF
--- a/sljit_src/sljitExecAllocator.c
+++ b/sljit_src/sljitExecAllocator.c
@@ -166,23 +166,28 @@ static SLJIT_INLINE void apple_update_wx_flags(sljit_s32 enable_exec)
 static SLJIT_INLINE void* alloc_chunk(sljit_uw size)
 {
 	void *retval;
-	const int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+	int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+	int flags = MAP_PRIVATE;
+	int fd = -1;
+
+#ifdef PROT_MAX
+	prot |= PROT_MAX(prot);
+#endif
 
 #ifdef MAP_ANON
-	int flags = MAP_PRIVATE | MAP_ANON | SLJIT_MAP_JIT;
-
-	retval = mmap(NULL, size, prot, flags, -1, 0);
+	flags |= MAP_ANON | SLJIT_MAP_JIT;
 #else /* !MAP_ANON */
 	if (SLJIT_UNLIKELY((dev_zero < 0) && open_dev_zero()))
 		return NULL;
 
-	retval = mmap(NULL, size, prot, MAP_PRIVATE, dev_zero, 0);
+	fd = dev_zero;
 #endif /* MAP_ANON */
 
+	retval = mmap(NULL, size, prot, flags, fd, 0);
 	if (retval == MAP_FAILED)
 		return NULL;
 
-	if (mprotect(retval, size, prot) < 0) {
+	if (mprotect(retval, size, PROT_READ | PROT_WRITE | PROT_EXEC) < 0) {
 		munmap(retval, size);
 		return NULL;
 	}

--- a/sljit_src/sljitWXExecAllocator.c
+++ b/sljit_src/sljitWXExecAllocator.c
@@ -121,14 +121,18 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 	static pthread_mutex_t se_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 	static int se_protected = !SLJIT_PROT_WX;
+	int prot = PROT_READ | PROT_WRITE | SLJIT_PROT_WX;
 	sljit_uw* ptr;
 
 	if (SLJIT_UNLIKELY(se_protected < 0))
 		return NULL;
 
+#ifdef PROT_MAX
+	prot |= PROT_MAX(PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
+
 	size += sizeof(sljit_uw);
-	ptr = (sljit_uw*)mmap(NULL, size, PROT_READ | PROT_WRITE | SLJIT_PROT_WX,
-				MAP_PRIVATE | MAP_ANON, -1, 0);
+	ptr = (sljit_uw*)mmap(NULL, size, prot, MAP_PRIVATE | MAP_ANON, -1, 0);
 
 	if (ptr == MAP_FAILED)
 		return NULL;


### PR DESCRIPTION
starting with FreeBSD 13 an additional restriction on the way page
permissions are allowed to shift was added by indicating at mmap
time the maximum expected value using PROT_MAX.

indicate that the allocated page is also expected to have execute
permissions to avoid future silent failures at mprotect time.