### PR TITLE
macos: avoid mprotect checks since 11.2

### DIFF
--- a/sljit_src/sljitExecAllocator.c
+++ b/sljit_src/sljitExecAllocator.c
@@ -182,10 +182,12 @@ static SLJIT_INLINE void* alloc_chunk(sljit_uw size)
 	if (retval == MAP_FAILED)
 		return NULL;
 
+#ifdef SLIJT_WX_OS_NEEDSCHEK
 	if (mprotect(retval, size, prot) < 0) {
 		munmap(retval, size);
 		return NULL;
 	}
+#endif
 
 	SLJIT_UPDATE_WX_FLAGS(retval, (uint8_t *)retval + size, 0);
 


### PR DESCRIPTION
starting with macOS 11.2, the mprotect calls for RWX pages will fail at
least in Apple Silicon.

avoid the additional check that was originally added to workaround WX
implementations that lie about the permission of pages that were
allocated (ex: HardenedBSD) unless it has been specifically requested
(through a compile flag).

for macOS this allows the implementation provided for Apple Silicon in
hardware through pthread_jit_write_protect_np() for the versions that
had that support.

fixes: #99