### PR TITLE
misc: fix -Wextra related errors

### DIFF
--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -1669,6 +1669,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_OVERFLOW:
 		if (!(compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD_SUB))
 			return 0x0;
+		/* fallthrough */
 
 	case SLJIT_UNORDERED_F64:
 		return 0x7;
@@ -1676,6 +1677,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_OVERFLOW:
 		if (!(compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD_SUB))
 			return 0x1;
+		/* fallthrough */
 
 	case SLJIT_ORDERED_F64:
 		return 0x6;
@@ -1933,16 +1935,19 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 		break;
 	case SLJIT_MOV_S8:
 		sign = 1;
+		/* fallthrough */
 	case SLJIT_MOV_U8:
 		inst = STURBI | (MEM_SIZE_SHIFT(BYTE_SIZE) << 30) | 0x400;
 		break;
 	case SLJIT_MOV_S16:
 		sign = 1;
+		/* fallthrough */
 	case SLJIT_MOV_U16:
 		inst = STURBI | (MEM_SIZE_SHIFT(HALF_SIZE) << 30) | 0x400;
 		break;
 	case SLJIT_MOV_S32:
 		sign = 1;
+		/* fallthrough */
 	case SLJIT_MOV_U32:
 	case SLJIT_MOV32:
 		inst = STURBI | (MEM_SIZE_SHIFT(INT_SIZE) << 30) | 0x400;

--- a/sljit_src/sljitNativeMIPS_common.c
+++ b/sljit_src/sljitNativeMIPS_common.c
@@ -2258,6 +2258,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_flags(struct sljit_compiler *co
 	case SLJIT_GREATER_F64:
 	case SLJIT_LESS_EQUAL_F64:
 		type ^= 0x1; /* Flip type bit for the XORI below. */
+		/* fallthrough */
 	case SLJIT_EQUAL_F64:
 	case SLJIT_NOT_EQUAL_F64:
 	case SLJIT_LESS_F64:


### PR DESCRIPTION
Since d345a64 (misc: build/documentation fixes from recent changes
(#113), 2022-02-13), and as initially fixed in 92fcb0f (Fix fallthrough
errors., 2022-02-13); the build will be broken in modern versions of gcc
that will warn with -Wimplicit-fallthrough (included as part of -Wextra).

Make sure all architectures have the corresponding tags to avoid this
as required.

Additionally, avoid -Wunused-parameter errors from s390x from parameters
that weren't needed or are still pending implementation.