### PR TITLE
s390x: be explicit about cache coherence needs

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -341,7 +341,8 @@ extern "C" {
 
 #ifndef SLJIT_CACHE_FLUSH
 
-#if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86)
+#if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86) \
+	|| (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X)
 
 /* Not required to implement on archs with unified caches. */
 #define SLJIT_CACHE_FLUSH(from, to)


### PR DESCRIPTION
Practically not needed, as the current code will otherwise fallthrough
to the gcc check below that sets the builtin (which does nothing) for
gcc < 10 (like Ubuntu 20.04 or RHEL 8) or never hit this for gcc >= 10.