### PR TITLE
macos: fix recent regression breaking build in macos/arm64e

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -323,6 +323,16 @@ extern "C" {
 /* Instruction cache flush. */
 /****************************/
 
+/*
+ * TODO:
+ *
+ * clang >= 15 could be safe to enable below
+ * older versions are known to abort in some targets
+ * https://github.com/PhilipHazel/pcre2/issues/92
+ *
+ * beware APPLE is known to have removed the code in iOS so
+ * it will need to be excempted or result in broken builds
+ */
 #if (!defined SLJIT_CACHE_FLUSH && defined __has_builtin)
 #if __has_builtin(__builtin___clear_cache) && !defined(__clang__)
 
@@ -352,9 +362,9 @@ extern "C" {
 /* Supported by all macs since Mac OS 10.5.
    However, it does not work on non-jailbroken iOS devices,
    although the compilation is successful. */
-
+#include <libkern/OSCacheControl.h>
 #define SLJIT_CACHE_FLUSH(from, to) \
-	sys_icache_invalidate((char*)(from), (char*)(to) - (char*)(from))
+	sys_icache_invalidate((void*)(from), (size_t)((char*)(to) - (char*)(from)))
 
 #elif (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
 
@@ -370,26 +380,26 @@ extern "C" {
 	sparc_cache_flush((from), (to))
 #define SLJIT_CACHE_FLUSH_OWN_IMPL 1
 
-#elif (defined(__GNUC__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+#elif (defined(__GNUC__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))) || defined(__clang__)
 
 #define SLJIT_CACHE_FLUSH(from, to) \
 	__builtin___clear_cache((char*)(from), (char*)(to))
 
 #elif defined __ANDROID__
 
-/* Android lacks __clear_cache; instead, cacheflush should be used. */
-
+/* Android ARMv7 with gcc lacks __clear_cache; use cacheflush instead. */
+#include <sys/cachectl.h>
 #define SLJIT_CACHE_FLUSH(from, to) \
-    cacheflush((long)(from), (long)(to), 0)
+	cacheflush((long)(from), (long)(to), 0)
 
 #elif defined _WIN32
 
 #define SLJIT_CACHE_FLUSH(from, to) \
-	FlushInstructionCache(GetCurrentProcess(), (char*)(from), (char*)(to) - (char*)(from))
+	FlushInstructionCache(GetCurrentProcess(), (void*)(from), (char*)(to) - (char*)(from))
 
 #else
 
-/* Calls __ARM_NR_cacheflush on ARM-Linux. */
+/* Call __ARM_NR_cacheflush on ARM-Linux or the corresponding MIPS syscall. */
 #define SLJIT_CACHE_FLUSH(from, to) \
 	__clear_cache((char*)(from), (char*)(to))
 


### PR DESCRIPTION
Since 75a5556 (power: avoid bogus clear_cache builtin in gcc >= 10 (#118),
2022-03-18), builds in macOS/arm64 will fail because of a missing function
definition for sys_icache_invalidate.

The reason why that code is suddenly excercised, is because before the
excemption added in that commit, clang will report its builtin and use
that instead.

Using the builtin in arm is problematic, because it could fail and the
builtin doesn't report failures[1] and so it is better to use the system
specific code in this case, but to do so the header needs to be added and
the parameters cast to the correct types.

As a sideeffect, the use of an APPLE specific API unbreaks the build in
iOS, so add a comment to take that into consideration when/if using the
builtin with clang is preferred later.

To avoid further regressions, reenable the use of the builtin once the
sparc and power fallbacks had been configured, and make sure that for the
case we are reaching into the android specific call, a header is also
present.

[1] https://gcc.gnu.org/bugzilla//show_bug.cgi?id=91053