### PR TITLE
windows: allow building with MinGW64 gcc/clang

### DIFF
--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -913,7 +913,11 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_compiler_verbose(struct sljit_compiler *comp
 
 #if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
 #ifdef _WIN64
+#ifdef __GNUC__
+#	define SLJIT_PRINT_D	"ll"
+#else
 #	define SLJIT_PRINT_D	"I64"
+#endif
 #else
 #	define SLJIT_PRINT_D	"l"
 #endif


### PR DESCRIPTION
Fix building with MinGW in Windows using either gcc or clang x86_64 target compilers.

Tested not to introduce regressions to MSVC builds with either Visual Studio or clang (CLangCL toolset) compilers.