### PR TITLE
macos: allow building with an os target older than 11.0

### DIFF
--- a/sljit_src/allocator_src/sljitExecAllocatorApple.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorApple.c
@@ -81,11 +81,10 @@ static SLJIT_INLINE int get_map_jit_flag()
 
 static SLJIT_INLINE void apple_update_wx_flags(sljit_s32 enable_exec)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
-	pthread_jit_write_protect_np(enable_exec);
-#else
-#error "Must target Big Sur or newer"
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
+	if (__builtin_available(macos 11, *))
 #endif /* BigSur */
+	pthread_jit_write_protect_np(enable_exec);
 }
 #endif /* SLJIT_CONFIG_X86 */
 #else /* !TARGET_OS_OSX */


### PR DESCRIPTION
Make the Apple Silicon code smarter, so it can allow binaries built for not existent OS versions, to easy the pain of "fat binary" builders that need to target older versions than Big Sur.

Since those OS versions are not available, it can be safe to assume that the code can't fail at runtime either, but it will need adjusting if support is added for non macOS or other toolchains than clang (with compiler_rt) as provided by Xcode.

Note that since the code generated will have a runtime dependency in the toolchain used to build it, it is inherently non portable and should be ideally linked statically with binaries using the same toolchain.  A warning to make that more obvious to users of this "feature" might be worth adding, but has been punted for this version as it was known to cause confusion instead in previous reports.