### PR TITLE
Fix spelling of 'subtract'

### DIFF
--- a/API_CHANGES
+++ b/API_CHANGES
@@ -8,7 +8,7 @@ This file is the short summary of the API changes:
     Floating point comparison types are renamed.
 
 01.03.2022 - Non-backward compatible
-    Remove SLJIT_NEG. Instead substraction from
+    Remove SLJIT_NEG. Instead subtraction from
     immedate 0 is preferred.
 
 31.01.2022 - Non-backward compatible

--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -603,7 +603,7 @@ typedef double sljit_f64;
 #endif
 #endif /* SLJIT_INDIRECT_CALL */
 
-/* The offset which needs to be substracted from the return address to
+/* The offset which needs to be subtracted from the return address to
 determine the next executed instruction after return. */
 #ifndef SLJIT_RETURN_ADDRESS_OFFSET
 #define SLJIT_RETURN_ADDRESS_OFFSET 0

--- a/sljit_src/sljitNativePPC_common.c
+++ b/sljit_src/sljitNativePPC_common.c
@@ -1872,7 +1872,7 @@ static SLJIT_INLINE sljit_s32 sljit_emit_fop1_conv_f64_from_sw(struct sljit_comp
 	   The double precision format has exactly 53 bit precision, so the lower 32 bit represents
 	   the lower 32 bit of such value. The result of xor 2^31 is the same as adding 0x80000000
 	   to the input, which shifts it into the 0 - 0xffffffff range. To get the converted floating
-	   point value, we need to substract 2^53 + 2^31 from the constructed value. */
+	   point value, we need to subtract 2^53 + 2^31 from the constructed value. */
 	FAIL_IF(push_inst(compiler, ADDIS | D(TMP_REG2) | A(0) | 0x4330));
 	if (invert_sign)
 		FAIL_IF(push_inst(compiler, XORIS | S(src) | A(TMP_REG1) | 0x8000));

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -5504,7 +5504,7 @@ static void test55(void)
 
 static void test56(void)
 {
-	/* Check integer substraction with negative immediate. */
+	/* Check integer subtraction with negative immediate. */
 	executable_code code;
 	struct sljit_compiler* compiler = sljit_create_compiler(NULL, NULL);
 	sljit_sw buf[13];


### PR DESCRIPTION
substract(ion) -> subtract(ion)