### PR TITLE
FreeBSD 13.1 and above w/x pages fix.

### DIFF
--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -2201,7 +2201,8 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_put_label(struct sljit_co
 #if (defined SLJIT_CONFIG_X86 && SLJIT_CONFIG_X86) \
 		|| (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC) \
 		|| ((defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS) && !(defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1 && SLJIT_MIPS_REV < 6)) \
-		|| (defined SLJIT_CONFIG_RISCV && SLJIT_CONFIG_RISCV)
+		|| (defined SLJIT_CONFIG_RISCV && SLJIT_CONFIG_RISCV) \
+		|| (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X)
 
 static SLJIT_INLINE sljit_s32 sljit_emit_cmov_generic(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 dst_reg,


### PR DESCRIPTION
If kern.elf32/64.allow_wx sysctl settings is disabled then sljit cannot create pages with both w/x bits. However, procctl api allows to enable it per process.