### PR TITLE
Tcc compat

### DIFF
--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -329,7 +329,7 @@ static void get_cpu_features(void)
 	__cpuid(CPUInfo, 1);
 	features = (sljit_u32)CPUInfo[3];
 
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__SUNPRO_C)
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__SUNPRO_C) || defined(__TINYC__)
 
 	/* AT&T syntax. */
 	__asm__ (

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -347,9 +347,9 @@ static void get_cpu_features(void)
 		: "=g" (features)
 		:
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
-		: "%eax", "%ecx", "%edx"
+		: "eax", "ecx", "edx"
 #else
-		: "%rax", "%rbx", "%rcx", "%rdx"
+		: "rax", "rbx", "rcx", "rdx"
 #endif
 	);
 


### PR DESCRIPTION
These commits make sljit compatible to be build with tcc (issue #131).

Make sure to install tcc first:

```sh-session
root@x1:~ # apt install tcc
[...]
```

Afterwards sljit can be build like this:

```sh-session
minipli@x1:~/src/sljit (tcc_compat)$ make CC=tcc
tcc  -Isljit_src -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror -c -o bin/sljitMain.o test_src/sljitMain.c
tcc  -Isljit_src -DSLJIT_HAVE_CONFIG_PRE=1 -Itest_src -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror  bin/sljitMain.o test_src/sljitTest.c sljit_src/sljitLir.c -o bin/sljit_test -lm -lpthread
tcc  -Isljit_src -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror -fshort-wchar -c -o bin/regexMain.o regex_src/regexMain.c
tcc  -Isljit_src -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror -fshort-wchar -c -o bin/regexJIT.o regex_src/regexJIT.c
tcc  -Isljit_src -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror -c -o bin/sljitLir.o sljit_src/sljitLir.c
tcc -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror  bin/regexMain.o bin/regexJIT.o bin/sljitLir.o -o bin/regex_test -lm -lpthread
minipli@x1:~/src/sljit (tcc_compat)$ ./bin/sljit_test -s && ./bin/regex_test -s
SLJIT tests: all tests are PASSED on x86 64bit (little endian + unaligned) (with fpu)
REGEX tests: all tests are PASSED on x86 64bit (little endian + unaligned)

```