### PR TITLE
riscv: avoid SIGILL in 64bit while jumping

### DIFF
--- a/sljit_src/sljitNativeRISCV_common.c
+++ b/sljit_src/sljitNativeRISCV_common.c
@@ -236,7 +236,7 @@ static SLJIT_INLINE sljit_ins* detect_jump_type(struct sljit_jump *jump, sljit_i
 
 		jump->flags |= PATCH_ABS44;
 		inst[3] = inst[0];
-		return inst + 4;
+		return inst + 3;
 	}
 
 	if (target_addr <= S52_MAX) {


### PR DESCRIPTION
breaking test15 consistently when building against both available riscv nodes in the GCC compiler farm[1]

[1] https://cfarm.tetaneutral.net/machines/list/#