### PR TITLE
riscv: allow disabling the FPU on demand or if soft-float ABI is requested

### DIFF
--- a/sljit_src/sljitNativeRISCV_common.c
+++ b/sljit_src/sljitNativeRISCV_common.c
@@ -531,6 +531,13 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 {
 	switch (feature_type) {
 	case SLJIT_HAS_FPU:
+#ifdef SLJIT_IS_FPU_AVAILABLE
+		return SLJIT_IS_FPU_AVAILABLE;
+#elif defined(__riscv_float_abi_soft)
+		return 0;
+#else
+		return 1;
+#endif
 	case SLJIT_HAS_ZERO_REGISTER:
 		return 1;
 	default:


### PR DESCRIPTION
Mainly deal with the fact that the FPU was always enabled, even though is optional, and therefore it would fail if running the tests in a soft-float system.

Most OS target lp64d at a minimum though and most commercially available CPUs seem to include an FPU and the extensions to use it on its ISA, so no "distribution" is affected.