### PR TITLE
Virtual register checks in floating point conversions

### DIFF
--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -2746,8 +2746,11 @@ static SLJIT_INLINE sljit_s32 sljit_emit_fop1_conv_sw_from_f64(struct sljit_comp
 	sljit_s32 dst, sljit_sw dstw,
 	sljit_s32 src, sljit_sw srcw)
 {
-	sljit_s32 dst_r = FAST_IS_REG(dst) ? dst : TMP_REG1;
+	sljit_s32 dst_r;
 	sljit_u8 *inst;
+
+	CHECK_EXTRA_REGS(dst, dstw, (void)0);
+	dst_r = FAST_IS_REG(dst) ? dst : TMP_REG1;
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	if (GET_OPCODE(op) == SLJIT_CONV_SW_FROM_F64)
@@ -2770,6 +2773,8 @@ static SLJIT_INLINE sljit_s32 sljit_emit_fop1_conv_f64_from_sw(struct sljit_comp
 {
 	sljit_s32 dst_r = FAST_IS_REG(dst) ? dst : TMP_FREG;
 	sljit_u8 *inst;
+
+	CHECK_EXTRA_REGS(src, srcw, (void)0);
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	if (GET_OPCODE(op) == SLJIT_CONV_F64_FROM_SW)


### PR DESCRIPTION
There are no checks in conv_f64_from_sw or conv_sw_from_f64 on x86_32 for virtual registers, so the conversion will be incorrect if the word register happens to be virtual. This fixes that.

Simple test case:

```
#include "sljit_src/sljitLir.h"

#include <stdio.h>

int main()
{
    struct sljit_compiler *compiler;
    sljit_sw (*f1)(sljit_f64);
    sljit_f64 (*f2)(sljit_sw);

    compiler = sljit_create_compiler(NULL, NULL);
    sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, F64), 4, 0, 1, 0, 0);
    sljit_emit_fop1(compiler, SLJIT_CONV_SW_FROM_F64, SLJIT_R3, 0, SLJIT_FR0, 0);
    sljit_emit_return(compiler, SLJIT_MOV, SLJIT_R3, 0);
    f1 = sljit_generate_code(compiler);
    sljit_free_compiler(compiler);
    printf("%d\n", (int) f1(1234));

    compiler = sljit_create_compiler(NULL, NULL);
    sljit_emit_enter(compiler, 0, SLJIT_ARGS1(F64, W), 4, 1, 1, 0, 0);
    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R3, 0, SLJIT_S0, 0);
    sljit_emit_fop1(compiler, SLJIT_CONV_F64_FROM_SW, SLJIT_FR0, 0, SLJIT_R3, 0);
    sljit_emit_return(compiler, SLJIT_MOV_F64, SLJIT_FR0, 0);
    f2 = sljit_generate_code(compiler);
    sljit_free_compiler(compiler);
    printf("%f\n", f2(1234));

    return 0;
}
```

Expected output is 1234, then 1234.000000. On x86_32, actual output prior to this patch is garbage (whatever happened to be in the register in question).