### PR TITLE
Add atomic instructions

### DIFF
--- a/sljit_src/sljitLir.h
+++ b/sljit_src/sljitLir.h
@@ -1935,6 +1935,34 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_function_context(void** func_ptr, struct
 SLJIT_API_FUNC_ATTRIBUTE void sljit_free_unused_memory_exec(void);
 #endif
 
+/* Atomic load loads data from memory to a register atomically,
+   marking the memory location as locked if necessary.
+
+   base_reg must have the memory address the data should be loaded from
+   data_reg is the register the data will be loaded into
+   temp_reg is a register used to store temporary data while executing
+     the load operation
+
+   Flags: - (does not modify flags) */
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 base_reg,
+	sljit_s32 data_reg,
+	sljit_s32 temp_reg);
+
+/* Atomic store stores data from one register to memory atomically,
+   clearing a memory lock if necessary and successful.
+
+   base_reg must have the memory address the data should be stored to
+   data_reg is a register containing the data that will be stored
+   temp_reg is a register used to store temporary data while executing
+     the store operation
+
+   Flags: ZF is cleared if not successful */
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 base_reg,
+	sljit_s32 data_reg,
+	sljit_s32 temp_reg);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -185,6 +185,9 @@ static const sljit_u8 freg_lmap[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 1] = {
 #define CMP_r_rm	0x3b
 #define CMP_rm_r	0x39
 #define CMPS_x_xm	0xc2
+#define CMPXCHG	0xb1
+#define CMPXCHG8B	0xc7
+#define CMPXCHG_1B	0xb0
 #define CVTPD2PS_x_xm	0x5a
 #define CVTSI2SD_x_rm	0x2a
 #define CVTTSD2SI_r_xm	0x2c
@@ -207,6 +210,7 @@ static const sljit_u8 freg_lmap[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 1] = {
 #define JMP_rm		(/* GROUP_FF */ 4 << 3)
 #define LEA_r_m		0x8d
 #define LOOP_i8		0xe2
+#define LOCK		0xf0
 #define LZCNT_r_rm	(/* GROUP_F3 */ /* GROUP_0F */ 0xbd)
 #define MOV_r_rm	0x8b
 #define MOV_r_i32	0xb8
@@ -3650,3 +3654,134 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_sw new_consta
 	sljit_unaligned_store_sw((void*)addr, new_constant);
 	SLJIT_UPDATE_WX_FLAGS((void*)addr, (void*)(addr + sizeof(sljit_sw)), 1);
 }
+
+#define emit_single_byte_inst(instr)                 \
+	inst = (sljit_u8 *) ensure_buf(compiler, 1 + 1); \
+	FAIL_IF(!inst);                                  \
+	INC_SIZE(1);                                     \
+	*inst = instr;
+
+#define emit_double_inst(group, instr, source, source_w, dest, dest_w)        \
+	inst = emit_x86_instruction(compiler, 2, source, source_w, dest, dest_w); \
+	FAIL_IF(!inst);                                                           \
+	*inst++ = group;                                                          \
+	*inst = instr;
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 base_reg,
+	sljit_s32 data_reg,
+	sljit_s32 temp_reg)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_atomic_load(compiler, op, base_reg, data_reg, temp_reg));
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = op & SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+
+	EMIT_MOV(compiler, data_reg, 0, SLJIT_IMM, 0);
+
+	sljit_s32 opcode = op;
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MOV:
+	case SLJIT_MOV_U32:
+	case SLJIT_MOV32:
+	case SLJIT_MOV_U8:
+	case SLJIT_MOV_U16:
+		break;
+	case SLJIT_MOV32_U8:
+		opcode = SLJIT_MOV_U8;
+		break;
+	case SLJIT_MOV32_U16:
+		opcode = SLJIT_MOV_U16;
+		break;
+	default:
+		SLJIT_UNREACHABLE();
+	}
+	sljit_emit_mem_unaligned(compiler, opcode, data_reg, SLJIT_MEM1(base_reg), 0);
+	return SLJIT_SUCCESS;
+}
+
+SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler *compiler, sljit_s32 op,
+	sljit_s32 base_reg,
+	sljit_s32 data_reg,
+	sljit_s32 temp_reg)
+{
+	CHECK_ERROR();
+	CHECK(check_sljit_emit_atomic_store(compiler, op, base_reg, data_reg, temp_reg));
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = op & SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+
+	sljit_u8 *inst;
+	sljit_s32 reg4 = -1;
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = 0;
+#endif /* SLJIT_CONFIG_X86_64 */
+	EMIT_MOV(compiler, SLJIT_MEM1(SLJIT_SP), 0 * sizeof(sljit_sw), SLJIT_R0, 0);
+	if (base_reg == SLJIT_R0 || data_reg == SLJIT_R0 || temp_reg == SLJIT_R0) {
+		reg4 = (base_reg == SLJIT_R1 || data_reg == SLJIT_R1 || temp_reg == SLJIT_R1 ? (base_reg == SLJIT_R2 || data_reg == SLJIT_R2 || temp_reg == SLJIT_R2 ? SLJIT_R3 : SLJIT_R2) : SLJIT_R1);
+		EMIT_MOV(compiler, SLJIT_MEM1(SLJIT_SP), 1 * sizeof(sljit_sw), reg4, 0);
+		EMIT_MOV(compiler, reg4, 0, SLJIT_R0, 0);
+		if (base_reg == SLJIT_R0) {
+			base_reg = reg4;
+		} else if (data_reg == SLJIT_R0) {
+			data_reg = reg4;
+		} else if (temp_reg == SLJIT_R0) {
+			temp_reg = reg4;
+		}
+	} else {
+		EMIT_MOV(compiler, SLJIT_MEM1(SLJIT_SP), 1 * sizeof(sljit_sw), SLJIT_R0, 0);
+	}
+	EMIT_MOV(compiler, SLJIT_R0, 0, SLJIT_MEM1(base_reg), 0);
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = op & SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+
+	switch (GET_OPCODE(op)) {
+	case SLJIT_MOV:
+		break;
+	case SLJIT_MOV_U8:
+	case SLJIT_MOV32_U8:
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+		compiler->mode32 = 0;
+#endif /* SLJIT_CONFIG_X86_64 */
+		emit_single_byte_inst(LOCK);
+		emit_double_inst(GROUP_0F, CMPXCHG_1B, data_reg, 0, SLJIT_MEM1(base_reg), 0);
+		return SLJIT_SUCCESS;
+	case SLJIT_MOV_U16:
+	case SLJIT_MOV32_U16:
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+		compiler->mode32 = SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+		emit_single_byte_inst(GROUP_66);
+	case SLJIT_MOV32:
+	case SLJIT_MOV_U32:
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+		compiler->mode32 = SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+		break;
+	default:
+		SLJIT_UNREACHABLE();
+	}
+	emit_single_byte_inst(LOCK);
+	emit_double_inst(GROUP_0F, CMPXCHG, data_reg, 0, SLJIT_MEM1(base_reg), 0);
+
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = 0;
+#endif /* SLJIT_CONFIG_X86_64 */
+	if (reg4 != -1) {
+		EMIT_MOV(compiler, SLJIT_R0, 0, reg4, 0);
+		EMIT_MOV(compiler, reg4, 0, SLJIT_MEM1(SLJIT_SP), 1 * sizeof(sljit_sw));
+	} else {
+		EMIT_MOV(compiler, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_SP), 1 * sizeof(sljit_sw));
+	}
+#if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
+	compiler->mode32 = op & SLJIT_32;
+#endif /* SLJIT_CONFIG_X86_64 */
+	return SLJIT_SUCCESS;
+}
+#undef emit_single_byte_inst
+#undef emit_double_inst

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -11516,6 +11516,97 @@ static void test91(void)
 	successful_tests++;
 }
 
+static void test92(void)
+{
+	/* Test atomic load and store. */
+	executable_code code;
+	struct sljit_compiler *compiler = sljit_create_compiler(NULL, NULL);
+#define datatype u_int64_t
+	datatype buf[7];
+
+	if (verbose)
+		printf("Run test92\n");
+
+	FAILED(!compiler, "cannot create compiler\n");
+
+	buf[0] = 0xffffffffffffffff;
+	buf[1] = 0xffffffffffffffff;
+	buf[2] = 0xffffffffffffffff;
+	buf[3] = 0xffffffffffffffff;
+	buf[4] = 0xffffffffffffffff;
+	buf[5] = 0xffffffffffffffff;
+	buf[6] = 0xffffffffffffffff;
+
+	sljit_emit_enter(compiler, 0, SLJIT_ARGS1(W, P), 4, 5, 4, 0, 2 * sizeof(sljit_sw));
+
+	/* buf[0] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 0 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[1] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 1 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV32, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV32 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[2] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 2 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV_U8, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV_U8 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[3] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 3 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV32_U8, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV32_U8 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[4] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 4 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV_U16, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV_U16 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[5] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 5 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV32_U16, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV32_U16 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+	/* buf[6] */
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R0, 0, SLJIT_S0, 0, SLJIT_IMM, 6 * sizeof(u_int64_t));
+	sljit_emit_atomic_load(compiler, SLJIT_MOV_U32, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+	sljit_emit_op2(compiler, SLJIT_ADD, SLJIT_R2, 0, SLJIT_R2, 0, SLJIT_IMM, (sljit_sw)0x1122334455667789);
+	sljit_emit_atomic_store(compiler, SLJIT_MOV_U32 | SLJIT_SET_Z, SLJIT_R0, SLJIT_R2, SLJIT_R3);
+
+
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
+	sljit_emit_return(compiler, SLJIT_MOV, SLJIT_RETURN_REG, 0);
+
+	code.code = sljit_generate_code(compiler);
+	CHECK(compiler);
+	sljit_free_compiler(compiler);
+
+	code.func1((sljit_sw) &buf);
+#if (defined SLJIT_64BIT_ARCHITECTURE && SLJIT_64BIT_ARCHITECTURE)
+	FAILED(buf[0] != 0x1122334455667788, "test92 case 1 failed\n");
+#else /* !SLJIT_64BIT_ARCHITECTURE */
+	FAILED(buf[0] != 0xffffffff55667788, "test92 case 1 failed\n");
+#endif /* SLJIT_64BIT_ARCHITECTURE */
+	FAILED(buf[1] != 0xffffffff55667788, "test92 case 2 failed\n");
+	FAILED(buf[2] != 0xffffffffffffff88, "test92 case 3 failed\n");
+	FAILED(buf[3] != 0xffffffffffffff88, "test92 case 4 failed\n");
+	FAILED(buf[4] != 0xffffffffffff7788, "test92 case 5 failed\n");
+	FAILED(buf[5] != 0xffffffffffff7788, "test92 case 6 failed\n");
+	FAILED(buf[6] != 0xffffffff55667788, "test92 case 7 failed\n");
+
+	sljit_free_code(code.code, NULL);
+	successful_tests++;
+#undef datatype
+}
+
 int sljit_test(int argc, char* argv[])
 {
 	sljit_s32 has_arg = (argc >= 2 && argv[1][0] == '-' && argv[1][2] == '\0');
@@ -11620,12 +11711,13 @@ int sljit_test(int argc, char* argv[])
 	test89();
 	test90();
 	test91();
+	test92();
 
 #if (defined SLJIT_EXECUTABLE_ALLOCATOR && SLJIT_EXECUTABLE_ALLOCATOR)
 	sljit_free_unused_memory_exec();
 #endif
 
-#	define TEST_COUNT 91
+#	define TEST_COUNT 92
 
 	printf("SLJIT tests: ");
 	if (successful_tests == TEST_COUNT)


### PR DESCRIPTION
This adds the required opcode defines, checks, tests and implementation for:
- x86_64
- x86_32
- aarch64
- ARM32 (v8 THUMB2)
- ARMv7