### PR TITLE
improve atomic instructions support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EXTRA_LDFLAGS=
 endif
 
 CPPFLAGS = $(EXTRA_CPPFLAGS) -Isljit_src
-CFLAGS += -O2 -Wall -Wextra -Wconversion -Wsign-compare -Werror
+CFLAGS += -O2 -Wall -Wextra -Wconversion -Wsign-compare -Wdeclaration-after-statement
 REGEX_CFLAGS += $(CFLAGS) -fshort-wchar
 LDFLAGS = $(EXTRA_LDFLAGS)
 

--- a/sljit_src/allocator_src/sljitExecAllocatorApple.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorApple.c
@@ -41,7 +41,7 @@
 #define SLJIT_MAP_JIT	(get_map_jit_flag())
 #define SLJIT_UPDATE_WX_FLAGS(from, to, enable_exec)
 
-static SLJIT_INLINE int get_map_jit_flag()
+static SLJIT_INLINE int get_map_jit_flag(void)
 {
 	size_t page_size;
 	void *ptr;

--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -2239,14 +2239,16 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_mem(struct sljit_compiler
 	sljit_s32 reg,
 	sljit_s32 mem, sljit_sw memw)
 {
+#if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS)
+	sljit_s32 allowed_flags;
+#endif
+
 	if (SLJIT_UNLIKELY(compiler->skip_checks)) {
 		compiler->skip_checks = 0;
 		CHECK_RETURN_OK;
 	}
 
 #if (defined SLJIT_ARGUMENT_CHECKS && SLJIT_ARGUMENT_CHECKS)
-	sljit_s32 allowed_flags;
-
 	if (type & SLJIT_MEM_UNALIGNED) {
 		CHECK_ARGUMENT(!(type & (SLJIT_MEM_UNALIGNED_16 | SLJIT_MEM_UNALIGNED_32)));
 	} else if (type & SLJIT_MEM_UNALIGNED_16) {
@@ -2258,14 +2260,14 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_mem(struct sljit_compiler
 	allowed_flags = SLJIT_MEM_UNALIGNED;
 
 	switch (type & 0xff) {
+	case SLJIT_MOV:
+	case SLJIT_MOV_P:
+		allowed_flags |= SLJIT_MEM_UNALIGNED_32;
+		/* fallthrough */
 	case SLJIT_MOV_U32:
 	case SLJIT_MOV_S32:
 	case SLJIT_MOV32:
-		allowed_flags = SLJIT_MEM_UNALIGNED | SLJIT_MEM_UNALIGNED_16;
-		break;
-	case SLJIT_MOV:
-	case SLJIT_MOV_P:
-		allowed_flags = SLJIT_MEM_UNALIGNED | SLJIT_MEM_UNALIGNED_16 | SLJIT_MEM_UNALIGNED_32;
+		allowed_flags |= SLJIT_MEM_UNALIGNED_16;
 		break;
 	}
 

--- a/sljit_src/sljitNativeARM_32.c
+++ b/sljit_src/sljitNativeARM_32.c
@@ -3920,12 +3920,16 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	sljit_s32 temp_reg)
 {
 #if (defined SLJIT_CONFIG_ARM_V7 && SLJIT_CONFIG_ARM_V7)
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_load(compiler, op, base_reg, data_reg, temp_reg));
 
-	sljit_emit_mem_unaligned(compiler, SLJIT_MOV, data_reg, SLJIT_IMM, 0);
-	sljit_u32 inst = CONDITIONAL;
+	SLJIT_UNUSED_ARG(temp_reg);
 
+	sljit_emit_mem_unaligned(compiler, SLJIT_MOV, data_reg, SLJIT_IMM, 0);
+
+	inst = CONDITIONAL;
 	switch (GET_OPCODE(op)) {
 		case SLJIT_MOV:
 		case SLJIT_MOV32:
@@ -3943,9 +3947,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 		default:
 			SLJIT_UNREACHABLE();
 	}
-	push_inst(compiler, inst | RN(base_reg) | RD(data_reg));
-	return SLJIT_SUCCESS;
+	return push_inst(compiler, inst | RN(base_reg) | RD(data_reg));
 #else /* !SLJIT_CONFIG_ARM_V7 */
+	SLJIT_UNUSED_ARG(compiler);
+	SLJIT_UNUSED_ARG(op);
+	SLJIT_UNUSED_ARG(base_reg);
+	SLJIT_UNUSED_ARG(data_reg);
+	SLJIT_UNUSED_ARG(temp_reg);
+
 	return SLJIT_ERR_UNSUPPORTED;
 #endif /* SLJIT_CONFIG_ARM_V7 */
 }
@@ -3956,12 +3965,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 	sljit_s32 temp_reg)
 {
 #if (defined SLJIT_CONFIG_ARM_V7 && SLJIT_CONFIG_ARM_V7)
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_store(compiler, op, base_reg, data_reg, temp_reg));
 
 	compiler->last_flags |= SLJIT_SET_Z;
-	sljit_u32 inst = CONDITIONAL;
 
+	inst = CONDITIONAL;
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
 	case SLJIT_MOV32:
@@ -3980,10 +3991,15 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 		SLJIT_UNREACHABLE();
 	}
 
-	push_inst(compiler, inst | RN(base_reg) | RD(temp_reg) | RM(data_reg));
-	push_inst(compiler, CMP_imm | RN(temp_reg) | 0);
-	return SLJIT_SUCCESS;
+	FAIL_IF(push_inst(compiler, inst | RN(base_reg) | RD(temp_reg) | RM(data_reg)));
+	return push_inst(compiler, CMP_imm | RN(temp_reg) | 0);
 #else /* !SLJIT_CONFIG_ARM_V7 */
+	SLJIT_UNUSED_ARG(compiler);
+	SLJIT_UNUSED_ARG(op);
+	SLJIT_UNUSED_ARG(base_reg);
+	SLJIT_UNUSED_ARG(data_reg);
+	SLJIT_UNUSED_ARG(temp_reg);
+
 	return SLJIT_ERR_UNSUPPORTED;
 #endif /* SLJIT_CONFIG_ARM_V7 */
 }

--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -2543,11 +2543,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_load(compiler, op, base_reg, data_reg, temp_reg));
 
+	SLJIT_UNUSED_ARG(temp_reg);
+
 	sljit_emit_mem_unaligned(compiler, SLJIT_MOV, data_reg, SLJIT_IMM, 0);
-	sljit_u32 inst = 0;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
@@ -2568,8 +2571,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	default:
 		SLJIT_UNREACHABLE();
 	}
-	push_inst(compiler, inst | RN(base_reg) | RT(data_reg));
-	return SLJIT_SUCCESS;
+	return push_inst(compiler, inst | RN(base_reg) | RT(data_reg));
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler *compiler, sljit_s32 op,
@@ -2577,10 +2579,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_store(compiler, op, base_reg, data_reg, temp_reg));
-
-	sljit_u32 inst = 0;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
@@ -2602,7 +2604,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 		SLJIT_UNREACHABLE();
 	}
 
-	push_inst(compiler, inst | RM(temp_reg) | RN(base_reg) | RT(data_reg));
-	push_inst(compiler, CMP_imm | IMM12(0) | RN(temp_reg));
-	return SLJIT_SUCCESS;
+	FAIL_IF(push_inst(compiler, inst | RM(temp_reg) | RN(base_reg) | RT(data_reg)));
+	return push_inst(compiler, CMP_imm | IMM12(0) | RN(temp_reg));
 }

--- a/sljit_src/sljitNativeARM_T2_32.c
+++ b/sljit_src/sljitNativeARM_T2_32.c
@@ -3297,11 +3297,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_load(compiler, op, base_reg, data_reg, temp_reg));
 
+	SLJIT_UNUSED_ARG(temp_reg);
+
 	sljit_emit_mem_unaligned(compiler, SLJIT_MOV, data_reg, SLJIT_IMM, 0);
-	sljit_u32 inst = 0;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
@@ -3320,8 +3323,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	default:
 		SLJIT_UNREACHABLE();
 	}
-	push_inst32(compiler, inst | RN4(base_reg) | RT4(data_reg));
-	return SLJIT_SUCCESS;
+	return push_inst32(compiler, inst | RN4(base_reg) | RT4(data_reg));
 }
 
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler *compiler, sljit_s32 op,
@@ -3329,11 +3331,12 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_u32 inst;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_store(compiler, op, base_reg, data_reg, temp_reg));
 
 	compiler->last_flags |= SLJIT_SET_Z;
-	sljit_u32 inst = 0;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
@@ -3353,7 +3356,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 		SLJIT_UNREACHABLE();
 	}
 
-	push_inst32(compiler, inst | RN4(base_reg) | RT4(data_reg)| RM4(temp_reg) );
-	push_inst16(compiler, CMP | IMM8(0) | RDN3(temp_reg));
-	return SLJIT_SUCCESS;
+	FAIL_IF(push_inst32(compiler, inst | RN4(base_reg) | RT4(data_reg)| RM4(temp_reg)));
+	return push_inst16(compiler, CMP | IMM8(0) | RDN3(temp_reg));
 }

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -3672,6 +3672,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_s32 opcode = op;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_load(compiler, op, base_reg, data_reg, temp_reg));
 
@@ -3680,8 +3682,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 #endif /* SLJIT_CONFIG_X86_64 */
 
 	EMIT_MOV(compiler, data_reg, 0, SLJIT_IMM, 0);
-
-	sljit_s32 opcode = op;
 
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV:
@@ -3708,14 +3708,14 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 	sljit_s32 data_reg,
 	sljit_s32 temp_reg)
 {
+	sljit_u8 *inst;
+	sljit_s32 reg4 = -1;
+
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_atomic_store(compiler, op, base_reg, data_reg, temp_reg));
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	compiler->mode32 = op & SLJIT_32;
 #endif /* SLJIT_CONFIG_X86_64 */
-
-	sljit_u8 *inst;
-	sljit_s32 reg4 = -1;
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
 	compiler->mode32 = 0;
@@ -3757,6 +3757,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_store(struct sljit_compiler
 		compiler->mode32 = SLJIT_32;
 #endif /* SLJIT_CONFIG_X86_64 */
 		emit_single_byte_inst(GROUP_66);
+		/* fallthrough */
 	case SLJIT_MOV32:
 	case SLJIT_MOV_U32:
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)


### PR DESCRIPTION
Use an ISO C standard type and avoid failing tests for the unsupported ARMv5 platform.

Missing support for other architectures that affects building punted.