### PR TITLE
x86_64: correctly detect mode32 for atomic_store

### DIFF
--- a/sljit_src/sljitLir.h
+++ b/sljit_src/sljitLir.h
@@ -1772,6 +1772,10 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fmem_update(struct sljit_compiler 
    Note: atomic operations are experimental, and
      not implemented for all cpus.
 
+   Note: the base address (mem_reg) might be aligned to the natural
+     size of the memory operation (op), otherwise the operation is
+     undefined.
+
    Note: the memory operation (op) and the base address (mem_reg)
      passed to sljit_emit_atomic_load and sljit_emit_atomic_store
      must be the same, otherwise the operation is undefined.

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -11541,7 +11541,7 @@ static void test92(void)
 	for (i = 0; i < 32; i++)
 		buf[i] = -1;
 
-	buf[0] = -4678;
+	buf[0] = 4678;
 	*(sljit_u8*)(buf + 2) = 178;
 	*(sljit_u8*)(buf + 5) = 211;
 	*(sljit_u16*)(buf + 9) = 17897;
@@ -11714,8 +11714,9 @@ static void test92(void)
 	sljit_free_compiler(compiler);
 
 	code.func1((sljit_sw)&buf);
+
 	FAILED(buf[0] != -9856, "test92 case 1 failed\n");
-	FAILED(buf[1] != -4678, "test92 case 2 failed\n");
+	FAILED(buf[1] != 4678, "test92 case 2 failed\n");
 	FAILED(*(sljit_u8*)(buf + 2) != 203, "test92 case 3 failed\n");
 	FAILED(((sljit_u8*)(buf + 2))[1] != 0xff, "test92 case 4 failed\n");
 	FAILED(buf[3] != 178, "test92 case 5 failed\n");


### PR DESCRIPTION
test 92 case 1 not failing because of an unlucky choice of test values.