### PR TITLE
Fix incorrect branch offset calculation

### DIFF
--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -201,7 +201,7 @@ static SLJIT_INLINE sljit_sw detect_jump_type(struct sljit_jump *jump, sljit_ins
 		target_addr = (sljit_uw)(code + jump->u.label->size) + (sljit_uw)executable_offset;
 	}
 
-	diff = (sljit_sw)target_addr - (sljit_sw)(code_ptr + 4) - executable_offset;
+	diff = (sljit_sw)target_addr - (sljit_sw)(code_ptr - 4) - executable_offset;
 
 	if (jump->flags & IS_COND) {
 		diff += SSIZE_OF(ins);


### PR DESCRIPTION
This now uses the same offset calculation as sljit_generate_code. Before, if you had an address that was 16 bytes off from the maximum, it would overflow the 26 bit signed int available to the "bl" instruction. In other words, it would choose "bl" when it should have chosen "blr". This typically caused a crash because the jump was to an invalid address.