### PR TITLE
simd: prevent SIGILL with armv6

### DIFF
--- a/regex_src/regexMain.c
+++ b/regex_src/regexMain.c
@@ -211,9 +211,9 @@ static void run_tests(struct test_case* test, int verbose, int silent)
 
 	printf("REGEX tests: ");
 	if (fail == 0)
-		printf("all tests are " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
+		printf("all tests " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
 	else
-		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests are failed ", fail, fail * 100 / (success + fail));
+		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests failed ", fail, fail * 100 / (success + fail));
 	printf("on " COLOR_ARCH "%s" COLOR_DEFAULT "\n", regex_get_platform_name());
 }
 

--- a/sljit_src/sljitNativeARM_32.c
+++ b/sljit_src/sljitNativeARM_32.c
@@ -974,15 +974,25 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 {
 	switch (feature_type) {
 	case SLJIT_HAS_FPU:
-	case SLJIT_HAS_SIMD:
-	case SLJIT_SIMD_REGS_ARE_PAIRS:
 #ifdef SLJIT_IS_FPU_AVAILABLE
 		return SLJIT_IS_FPU_AVAILABLE;
 #else
 		/* Available by default. */
 		return 1;
-#endif
+#endif /* SLJIT_IS_FPU_AVAILABLE */
+	case SLJIT_HAS_SIMD:
+#ifdef SLJIT_IS_FPU_AVAILABLE
+		return SLJIT_IS_FPU_AVAILABLE;
+#else
+#if (defined SLJIT_CONFIG_ARM_V6 && SLJIT_CONFIG_ARM_V6)
+		return 0;
+#else
+		/* Available by default. */
+		return 1;
+#endif /* SLJIT_CONFIG_ARM_V6 */
+#endif /* SLJIT_IS_FPU_AVAILABLE */
 
+	case SLJIT_SIMD_REGS_ARE_PAIRS:
 	case SLJIT_HAS_CLZ:
 	case SLJIT_HAS_CTZ:
 	case SLJIT_HAS_ROT:

--- a/sljit_src/sljitNativeARM_T2_32.c
+++ b/sljit_src/sljitNativeARM_T2_32.c
@@ -511,7 +511,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 	switch (feature_type) {
 	case SLJIT_HAS_FPU:
 	case SLJIT_HAS_SIMD:
-	case SLJIT_SIMD_REGS_ARE_PAIRS:
 #ifdef SLJIT_IS_FPU_AVAILABLE
 		return SLJIT_IS_FPU_AVAILABLE;
 #else
@@ -519,6 +518,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 		return 1;
 #endif
 
+	case SLJIT_SIMD_REGS_ARE_PAIRS:
 	case SLJIT_HAS_CLZ:
 	case SLJIT_HAS_CTZ:
 	case SLJIT_HAS_REV:

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -11276,7 +11276,7 @@ static void test90(void)
 	sljit_s32 i;
 
 	if (verbose)
-		printf("Run test89\n");
+		printf("Run test90\n");
 
 	FAILED(!compiler, "cannot create compiler\n");
 
@@ -11378,7 +11378,7 @@ static void test91(void)
 	sljit_s32 i;
 
 	if (verbose)
-		printf("Run test13\n");
+		printf("Run test91\n");
 
 	if (!sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		if (verbose)
@@ -12244,6 +12244,9 @@ static void test96(void)
 	sljit_u8 data[63 + 680];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
 
+	if (verbose)
+		printf("Run test96\n");
+
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
 			printf("no simd available, test96 skipped\n");
@@ -12441,6 +12444,9 @@ static void test97(void)
 	sljit_sw result[6];
 	sljit_s32 result32[5];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
+
+	if (verbose)
+		printf("Run test97\n");
 
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
@@ -12774,6 +12780,9 @@ static void test98(void)
 	sljit_u8 data[63 + 544];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
 
+	if (verbose)
+		printf("Run test98\n");
+
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
 			printf("no simd available, test98 skipped\n");
@@ -13021,6 +13030,9 @@ static void test99(void)
 	sljit_u8 data[63 + 464];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
 
+	if (verbose)
+		printf("Run test99\n");
+
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
 			printf("no simd available, test99 skipped\n");
@@ -13235,6 +13247,9 @@ static void test100(void)
 	sljit_u8* buf;
 	sljit_u8 data[63 + 368];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
+
+	if (verbose)
+		printf("Run test100\n");
 
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
@@ -13522,6 +13537,9 @@ static void test101(void)
 	sljit_u8* buf;
 	sljit_u8 data[63 + 544];
 	sljit_s32 fs0 = SLJIT_NUMBER_OF_SAVED_FLOAT_REGISTERS > 0 ? SLJIT_FS0 : SLJIT_FR5;
+
+	if (verbose)
+		printf("Run test101\n");
 
 	if (!sljit_has_cpu_feature(SLJIT_HAS_SIMD)) {
 		if (verbose)
@@ -13847,10 +13865,10 @@ int sljit_test(int argc, char* argv[])
 
 	printf("SLJIT tests: ");
 	if (successful_tests == TEST_COUNT)
-		printf("all tests are " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
+		printf("all tests " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
 	else
-		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests are " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / TEST_COUNT);
-	printf("on " COLOR_ARCH "%s" COLOR_DEFAULT "%s\n", sljit_get_platform_name(), sljit_has_cpu_feature(SLJIT_HAS_FPU) ? " (with fpu)" : " (without fpu)");
+		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / TEST_COUNT);
+	printf("on " COLOR_ARCH "%s" COLOR_DEFAULT " (%s)\n", sljit_get_platform_name(), sljit_has_cpu_feature(SLJIT_HAS_SIMD) ? "with simd" : (sljit_has_cpu_feature(SLJIT_HAS_FPU) ? "with fpu" : "basic"));
 
 	return TEST_COUNT - successful_tests;
 


### PR DESCRIPTION
NEON was introduced as an optional feature with armv7, so disable it for earlier versions.