### PR TITLE
arm: fix not aligned register pair thumb2 operations

### DIFF
--- a/sljit_src/sljitNativeARM_T2_32.c
+++ b/sljit_src/sljitNativeARM_T2_32.c
@@ -3027,7 +3027,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 				imm = get_imm((sljit_uw)(memw & ~0xfff));
 
 				if (imm != INVALID_IMM)
-					memw &= 0xff;
+					memw &= 0xfff;
 			}
 
 			if (imm == INVALID_IMM) {


### PR DESCRIPTION
Mask up to 12bits for the offset to avoid truncation. Triggering in test79 case 21 when running in QEMU, somehow