### PR TITLE
atomic: avoid unused checks if not implemented

### DIFF
--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -1408,6 +1408,13 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_op1(struct sljit_compiler
 	CHECK_RETURN_OK;
 }
 
+/* experimental API, only implemented for: */
+
+#if (defined(SLJIT_CONFIG_X86) && SLJIT_CONFIG_X86) \
+	|| (defined(SLJIT_CONFIG_ARM) && SLJIT_CONFIG_ARM) \
+	|| (defined(SLJIT_CONFIG_S390X) && SLJIT_CONFIG_S390X) \
+	|| (defined(SLJIT_CONFIG_LOONGARCH) && SLJIT_CONFIG_LOONGARCH)
+
 static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_atomic_load(struct sljit_compiler *compiler, sljit_s32 op,
 	sljit_s32 dst_reg,
 	sljit_s32 mem_reg)
@@ -1493,6 +1500,8 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_atomic_store(struct sljit
 #endif /* SLJIT_VERBOSE */
 	CHECK_RETURN_OK;
 }
+
+#endif /* !SLJIT_CONFIG_PPC && !SLJIT_CONFIG_MIPS && !SLJIT_CONFIG_RISCV */
 
 static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_op2(struct sljit_compiler *compiler, sljit_s32 op, sljit_s32 unset,
 	sljit_s32 dst, sljit_sw dstw,


### PR DESCRIPTION
mainly to avoid unused function warnings with clang on the architectures that are yet to be implemented