### PR TITLE
mips: correctly detect valid FPU and support StatusFR=1 in 32bit

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -397,9 +397,10 @@ typedef double sljit_f64;
 /* Auto detecting mips revision. */
 #if (defined __mips_isa_rev) && (__mips_isa_rev >= 6)
 #define SLJIT_MIPS_REV 6
-#elif (defined __mips_isa_rev && __mips_isa_rev >= 1) \
-	|| (defined __clang__ && defined _MIPS_ARCH_OCTEON) \
-	|| (defined __clang__ && defined _MIPS_ARCH_P5600)
+#elif defined(__mips_isa_rev) && __mips_isa_rev >= 1
+#define SLJIT_MIPS_REV __mips_isa_rev
+#elif defined(__clang__) \
+	&& (defined(_MIPS_ARCH_OCTEON) || defined(_MIPS_ARCH_P5600))
 /* clang either forgets to define (clang-7) __mips_isa_rev at all
  * or sets it to zero (clang-8,-9) for -march=octeon (MIPS64 R2+)
  * and -march=p5600 (MIPS32 R5).

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -6173,11 +6173,11 @@ static void test58(void)
 	dbuf[5] = 0.0;
 	dbuf[6] = -18.0;
 
-	sbuf[0] = 6.75;
-	sbuf[1] = -3.5;
-	sbuf[2] = 1.5;
-	sbuf[3] = 0.0;
-	sbuf[4] = 0.0;
+	sbuf[0] = 6.75f;
+	sbuf[1] = -3.5f;
+	sbuf[2] = 1.5f;
+	sbuf[3] = 0.0f;
+	sbuf[4] = 0.0f;
 
 	wbuf[0] = 0;
 	wbuf[1] = 0;
@@ -6387,8 +6387,8 @@ static void test59(void)
 
 	if (sljit_has_cpu_feature(SLJIT_HAS_FPU)) {
 		FAILED(wbuf[4] != -88, "test59 case 4 failed\n");
-		FAILED(sbuf[2] != 79.75, "test59 case 5 failed\n");
-		FAILED(sbuf[3] != 8.625, "test59 case 6 failed\n");
+		FAILED(sbuf[2] != 79.75f, "test59 case 5 failed\n");
+		FAILED(sbuf[3] != 8.625f, "test59 case 6 failed\n");
 	}
 
 	sljit_free_code(code.code, NULL);


### PR DESCRIPTION
Mostly fixes issues when running through `qemu` and compatibility with newer CPUs that don't support or discourage the use of emulated 32bit FPU registers.

It doesn't address all endianess issues though but will run cleanly in both 32/64bit big endian and addresses manipulation of unaligned doubles which need to be loaded in the right order to avoid unpredictable values as described in:

```
When paired with MTC1 to write a value to a 64-bit FPR, the MTC1 must be executed first, followed by the MTHC1.
This is because of the semantic definition of MTC1, which is not aware that software is using an MTHC1 instruction
to complete the operation, and sets the upper half of the 64-bit FPR to an UNPREDICTABLE value. 
```