### PR TITLE
mips: enable SLJIT_HAVE_REV for SLJIT_MIPS_REV >= 2

### DIFF
--- a/doc/overview.txt
+++ b/doc/overview.txt
@@ -49,9 +49,9 @@ is a valid instruction sequence:
     sljit_emit_op1(compiler, SLJIT_MOV32,
         SLJIT_R0, 0, SLJIT_MEM1(SLJIT_R1), 0);
     // An int32_t value is loaded into SLJIT_R0
-    sljit_emit_op1(compiler, SLJIT_NOT32,
+    sljit_emit_op1(compiler, SLJIT_REV32,
         SLJIT_R0, 0, SLJIT_R0, 0);
-    // the int32_t value in SLJIT_R0 is bit inverted
+    // the int32_t value in SLJIT_R0 is byte swapped
     // and the type of the result is still int32_t
 
 The next code snippet is not allowed:
@@ -59,14 +59,14 @@ The next code snippet is not allowed:
     sljit_emit_op1(compiler, SLJIT_MOV,
         SLJIT_R0, 0, SLJIT_MEM1(SLJIT_R1), 0);
     // An intptr_t value is loaded into SLJIT_R0
-    sljit_emit_op1(compiler, SLJIT_NOT32,
+    sljit_emit_op1(compiler, SLJIT_REV32,
         SLJIT_R0, 0, SLJIT_R0, 0);
-    // The result of SLJIT_NOT instruction
-    // is undefined. Even crash is possible
+    // The result of the instruction is undefined.
+    // Even crash is possible for some instructions
     // (e.g. on MIPS-64).
 
 However, it is always allowed to overwrite a
-register regardless its previous value:
+register regardless of its previous value:
 
     sljit_emit_op1(compiler, SLJIT_MOV,
         SLJIT_R0, 0, SLJIT_MEM1(SLJIT_R1), 0);

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -11146,9 +11146,9 @@ static void test89(void)
 	/* Test reverse two bytes. */
 	executable_code code;
 	struct sljit_compiler* compiler = sljit_create_compiler(NULL, NULL);
-	sljit_sw buf[5];
+	sljit_sw buf[7];
 	sljit_s32 ibuf[4];
-	sljit_s16 hbuf[8];
+	sljit_s16 hbuf[11];
 	sljit_s32 i;
 
 	if (verbose)
@@ -11156,11 +11156,11 @@ static void test89(void)
 
 	FAILED(!compiler, "cannot create compiler\n");
 
-	for (i = 0; i < 5; i++)
+	for (i = 0; i < 7; i++)
 		buf[i] = -1;
 	for (i = 0; i < 4; i++)
 		ibuf[i] = -1;
-	for (i = 0; i < 8; i++)
+	for (i = 0; i < 11; i++)
 		hbuf[i] = -1;
 
 	hbuf[0] = (sljit_s16)0x8c9d;
@@ -11234,9 +11234,25 @@ static void test89(void)
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, 6 * sizeof(sljit_s16));
 	/* hbuf[6] */
 	sljit_emit_op1(compiler, SLJIT_REV32_S16, SLJIT_MEM2(SLJIT_S2, SLJIT_R1), 0, SLJIT_R3, 0);
-
 	/* hbuf[7] */
 	hbuf[7] = -367;
+
+#if IS_64BIT
+	/* SLJIT_REV truncates memory store, source not sign extended 64bit */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, (sljit_sw)0xdeadbeef4444aa55);
+	sljit_emit_op1(compiler, SLJIT_REV_U16, SLJIT_R1, 0, SLJIT_R0, 0);
+	/* buf[5] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 5 * sizeof(sljit_sw), SLJIT_R1, 0);
+	/* hbuf[8] */
+	sljit_emit_op1(compiler, SLJIT_MOV_U16, SLJIT_MEM1(SLJIT_S2), 8 * sizeof(sljit_u16), SLJIT_R1, 0);
+	/* hbuf[9] */
+	sljit_emit_op1(compiler, SLJIT_REV_S16, SLJIT_MEM1(SLJIT_S2), 9 * sizeof(sljit_u16), SLJIT_R0, 0);
+	/* hbuf[10] */
+	hbuf[10] = -42;
+	sljit_emit_op1(compiler, SLJIT_REV_S16, SLJIT_R0, 0, SLJIT_R0, 0);
+	/* buf[6] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 6 * sizeof(sljit_sw), SLJIT_R0, 0);
+#endif /* IS_64BIT */
 
 	sljit_emit_return_void(compiler);
 
@@ -11262,6 +11278,13 @@ static void test89(void)
 	FAILED(hbuf[5] != (sljit_s16)0x0201, "test89 case 14 failed\n");
 	FAILED(hbuf[6] != (sljit_s16)0x0201, "test89 case 15 failed\n");
 	FAILED(hbuf[7] != -367, "test89 case 16 failed\n");
+#if IS_64BIT
+	FAILED(hbuf[8] != 0x55aa, "test89 case 17 failed\n");
+	FAILED(buf[5] != hbuf[8], "test89 case 18 failed\n");
+	FAILED(hbuf[9] != hbuf[8], "test89 case 19 failed\n");
+	FAILED(hbuf[10] != -42, "test89 case 20 failed\n");
+	FAILED(buf[6] != hbuf[9], "test89 case 21 failed\n");
+#endif /* IS_64BIT */
 
 	sljit_free_code(code.code, NULL);
 	successful_tests++;
@@ -11272,8 +11295,8 @@ static void test90(void)
 	/* Test reverse four bytes. */
 	executable_code code;
 	struct sljit_compiler* compiler = sljit_create_compiler(NULL, NULL);
-	sljit_sw buf[12];
-	sljit_s32 ibuf[5];
+	sljit_sw buf[7];
+	sljit_s32 ibuf[6];
 	sljit_s32 i;
 
 	if (verbose)
@@ -11281,9 +11304,9 @@ static void test90(void)
 
 	FAILED(!compiler, "cannot create compiler\n");
 
-	for (i = 0; i < 12; i++)
+	for (i = 0; i < 7; i++)
 		buf[i] = -1;
-	for (i = 0; i < 5; i++)
+	for (i = 0; i < 6; i++)
 		ibuf[i] = -1;
 
 	sljit_emit_enter(compiler, 0, SLJIT_ARGS2(VOID, W, W), 5, 5, 0, 0, 2 * sizeof(sljit_sw));
@@ -11293,30 +11316,37 @@ static void test90(void)
 	/* buf[0] */
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 0, SLJIT_R0, 0);
 
+	/* Sign extend negative integer. */
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, WCONST(0xffffa1b2c3d4, 0xa1b2c3d4));
 	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_R1, 0, SLJIT_R2, 0);
 	/* buf[1] */
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), sizeof(sljit_sw), SLJIT_R1, 0);
 
+	/* Sign extend positive integer. */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, WCONST(0xffff1a2b3c4d,0x1a2b3c4d));
+	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_R1, 0, SLJIT_R2, 0);
+	/* buf[2] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 2 * sizeof(sljit_sw), SLJIT_R1, 0);
+
 	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_MEM1(SLJIT_S1), sizeof(sljit_s32), SLJIT_IMM, (sljit_s32)0xf9e8d7c6);
 	sljit_emit_op1(compiler, SLJIT_REV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_S1), sizeof(sljit_s32));
-	/* buf[2] */
-	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 2 * sizeof(sljit_sw), SLJIT_R2, 0);
+	/* buf[3] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 3 * sizeof(sljit_sw), SLJIT_R2, 0);
 
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, sizeof(sljit_s32));
 	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_S2, 0, SLJIT_MEM2(SLJIT_S1, SLJIT_R1), 0);
-	/* buf[3] */
-	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 3 * sizeof(sljit_sw), SLJIT_S2, 0);
+	/* buf[4] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 4 * sizeof(sljit_sw), SLJIT_S2, 0);
 
 	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_MEM1(SLJIT_SP), sizeof(sljit_sw), SLJIT_IMM, (sljit_s32)0xaabbccdd);
 	sljit_emit_op1(compiler, SLJIT_REV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_SP), sizeof(sljit_sw));
-	/* buf[4] */
-	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 4 * sizeof(sljit_sw), SLJIT_R2, 0);
+	/* buf[5] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 5 * sizeof(sljit_sw), SLJIT_R2, 0);
 
 	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_MEM1(SLJIT_SP), sizeof(sljit_sw), SLJIT_IMM, (sljit_s32)0xaabbccdd);
 	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_R4, 0, SLJIT_MEM1(SLJIT_SP), sizeof(sljit_sw));
-	/* buf[5] */
-	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 5 * sizeof(sljit_sw), SLJIT_R4, 0);
+	/* buf[6] */
+	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 6 * sizeof(sljit_sw), SLJIT_R4, 0);
 
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, WCONST(0xffff01020304, 0x01020304));
 	/* ibuf[0] */
@@ -11336,13 +11366,12 @@ static void test90(void)
 	/* ibuf[3] */
 	sljit_emit_op1(compiler, SLJIT_MOV32, SLJIT_MEM1(SLJIT_S1), 3 * sizeof(sljit_s32), SLJIT_MEM1(SLJIT_SP), sizeof(sljit_s32));
 
-	/* ibuf[4] */
-	ibuf[4] = -824;
-
+	/* SLJIT_REV memory store truncates and does not overflow */
 	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R4, 0, SLJIT_IMM, WCONST(0xffff8192a3b4, 0x8192a3b4));
-	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_S4, 0, SLJIT_R4, 0);
-	/* buf[6] */
-	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), 6 * sizeof(sljit_sw), SLJIT_S4, 0);
+	/* ibuf[4] */
+	sljit_emit_op1(compiler, SLJIT_REV_S32, SLJIT_MEM1(SLJIT_S1), 4 * sizeof(sljit_s32), SLJIT_R4, 0);
+	/* ibuf[5] */
+	ibuf[5] = 0x55555555;
 
 	sljit_emit_return_void(compiler);
 
@@ -11354,16 +11383,17 @@ static void test90(void)
 
 	FAILED(buf[0] != WCONST(0xd4c3b2a1, 0xd4c3b2a1), "test90 case 1 failed\n");
 	FAILED(buf[1] != WCONST(-0x2b3c4d5f, 0xd4c3b2a1), "test90 case 2 failed\n");
-	FAILED(buf[2] != WCONST(0xc6d7e8f9, 0xc6d7e8f9), "test90 case 3 failed\n");
-	FAILED(buf[3] != WCONST(-0x39281707, 0xc6d7e8f9), "test90 case 4 failed\n");
-	FAILED(buf[4] != WCONST(0xddccbbaa, 0xddccbbaa), "test90 case 5 failed\n");
-	FAILED(buf[5] != WCONST(-0x22334456, 0xddccbbaa), "test90 case 6 failed\n");
-	FAILED(ibuf[0] != 0x04030201, "test90 case 7 failed\n");
-	FAILED(ibuf[1] != 0x04030201, "test90 case 8 failed\n");
-	FAILED(ibuf[2] != (sljit_s32)0xc0d0e0f0, "test90 case 9 failed\n");
-	FAILED(ibuf[3] != (sljit_s32)0xc0d0e0f0, "test90 case 10 failed\n");
-	FAILED(ibuf[4] != -824, "test90 case 11 failed\n");
-	FAILED(buf[6] != WCONST(-0x4b5c6d7f, 0xb4a39281), "test90 case 12 failed\n");
+	FAILED(buf[2] != 0x4d3c2b1a, "test90 case 3 failed\n");
+	FAILED(buf[3] != WCONST(0xc6d7e8f9, 0xc6d7e8f9), "test90 case 4 failed\n");
+	FAILED(buf[4] != WCONST(-0x39281707, 0xc6d7e8f9), "test90 case 5 failed\n");
+	FAILED(buf[5] != WCONST(0xddccbbaa, 0xddccbbaa), "test90 case 6 failed\n");
+	FAILED(buf[6] != WCONST(-0x22334456, 0xddccbbaa), "test90 case 7 failed\n");
+	FAILED(ibuf[0] != 0x04030201, "test90 case 8 failed\n");
+	FAILED(ibuf[1] != 0x04030201, "test90 case 9 failed\n");
+	FAILED(ibuf[2] != (sljit_s32)0xc0d0e0f0, "test90 case 10 failed\n");
+	FAILED(ibuf[3] != (sljit_s32)0xc0d0e0f0, "test90 case 11 failed\n");
+	FAILED(ibuf[4] != (sljit_s32)0xb4a39281, "test90 case 12 failed\n");
+	FAILED(ibuf[5] != 0x55555555, "test90 case 13 failed\n");
 
 	sljit_free_code(code.code, NULL);
 	successful_tests++;


### PR DESCRIPTION
Adds 3 instructions from "revision 2" that allow for a new implementation of `SLJIT_REV` (and friends) that should be good enough to enable the corresponding `sljit_has_cpu_feature()` flag.

[documentation](https://github.com/zherczeg/sljit/blob/3dcdb25754363db2cd34dbd1cd9a6a6b880cadae/doc/overview.txt#L41-L44) for what is an invalid operation has been also updated.