### PR TITLE
Fix for generation of jump relative x86 instruction, arithmetic bug in decision between 32 and 64 bit address.

### DIFF
--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -604,7 +604,7 @@ static sljit_u8* generate_near_jump_code(struct sljit_jump *jump, sljit_u8 *code
 		label_addr = jump->u.target - (sljit_uw)executable_offset;
 
 #if (defined SLJIT_CONFIG_X86_64 && SLJIT_CONFIG_X86_64)
-	if ((sljit_sw)(label_addr - (jump->addr + 1)) > HALFWORD_MAX || (sljit_sw)(label_addr - (jump->addr + 1)) < HALFWORD_MIN)
+	if ((sljit_sw)(label_addr - (jump->addr + 2)) > HALFWORD_MAX || (sljit_sw)(label_addr - (jump->addr + 6)) < HALFWORD_MIN)
 		return generate_far_jump_code(jump, code_ptr);
 #endif
 


### PR DESCRIPTION
Splunk discovered a bug in PCRE2 which derives from the SLJIT code on x86_64. 

In particular the JIT would generate a 5-byte 32-bit relative call instruction with a jump of -0x80000003. This is just over what fits in 32-bits. Thus on the second pass when the address was inserted, it would get truncated to 0x7ffffffd which is now a positive jump address. This is a difference of exactly 0x100000000 - because the highest bit got dropped. The JIT should have realized that 0x80000003 would not fit in a 32-bit jump/call, and used a 64-bit instruction instead.

This is PIC code, so jumps are relative. On x86 call relative is relative to the next instruction.

In x86_64 (ia32e) the call relative instruction can have a 32-bit or a 64-bit operand. Both versions are allowed (the 16-bit version is not). The problem comes in when selecting which one to use. The calculation to decide whether to use the 64-bit jump instruction looks like this:

if ((sljit_sw)(label_addr - (jump->addr + 1)) > HALFWORD_MAX || (sljit_sw)(label_addr - (jump->addr + 1)) < HALFWORD_MIN)

The problem is that this calculation is ignoring the space the address itself takes (and I believe there is a case where the instruction can be 2 long, see the last else case of type == SLJIT_JUMP).

The longest this instruction can be on the 32-bit or smaller branch of the code is 6 bytes, and the shortest is 2 bytes. Since we don't know which we will pick yet, we should be conservative and ensure the 32-bit jump will work regardless of whether the instruction is 6 bytes or 2 bytes long. The instruction cannot in fact only be 1 byte long.

I believe this calculation should thus look like this:

if ((sljit_sw)(label_addr - (jump->addr + 2)) > HALFWORD_MAX || (sljit_sw)(label_addr - (jump->addr + 6)) < HALFWORD_MIN)

The first case is checking jumping to a larger address. In this case we want to check against the smallest possible starting address, for the largest possible total jump. The second case is checking jumping to a smaller address. In this case we want to check againts the largest possible address, for again the longest possible jump distance. Note that the change to the first case is not necessary. +1 is merely overly conservative by one byte.

Note that this bug is analogous to a similar bug Splunk recently discovered in the SLJIT code for Arm64, a pull request for which was filed by ilink@splunk.com.