### PR TITLE
s390x: fix FTBFS with clang

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,12 +23,16 @@ ifndef OPT_FLAGS
 OPT_FLAGS = -O2
 endif
 
+ifndef WARN_FLAGS
+WARN_FLAGS = -Wall -Wextra -Wconversion -Wsign-compare -Wdeclaration-after-statement -Wunused-function
+endif
+
 ifndef WERROR
 WERROR = -Werror
 endif
 
 CPPFLAGS = $(EXTRA_CPPFLAGS) -Isljit_src
-CFLAGS += $(OPT_FLAGS) -Wall -Wextra -Wconversion -Wsign-compare -Wdeclaration-after-statement $(WERROR)
+CFLAGS += $(OPT_FLAGS) $(WARN_FLAGS) $(WERROR)
 REGEX_CFLAGS += $(CFLAGS) -fshort-wchar
 LDFLAGS = $(EXTRA_LDFLAGS)
 

--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -3375,7 +3375,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_op2(struct sljit_compiler *co
 	sljit_s32 dst_freg, sljit_s32 src1_freg, sljit_s32 src2_freg)
 {
 	CHECK_ERROR();
-	CHECK(sljit_emit_simd_op2(compiler, type, dst_freg, src1_freg, src2_freg));
+	CHECK(check_sljit_emit_simd_op2(compiler, type, dst_freg, src1_freg, src2_freg));
 	SLJIT_UNUSED_ARG(compiler);
 	SLJIT_UNUSED_ARG(type);
 	SLJIT_UNUSED_ARG(dst_freg);


### PR DESCRIPTION
While at it, add the relevant warning to the default list so this kind of issues are easier to detect.