### PR TITLE
build: make code mostly ANSI C89 compatible

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,16 +7,8 @@ CC = gcc
 endif
 endif
 
-ifndef EXTRA_CPPFLAGS
-EXTRA_CPPFLAGS=
-endif
-
-ifndef EXTRA_LDFLAGS
-EXTRA_LDFLAGS=
-endif
-
-ifndef EXTRA_LIBS
-EXTRA_LIBS=
+ifndef COMPAT_FLAGS
+COMPAT_FLAGS = -std=c89 -pedantic -Wpedantic
 endif
 
 ifndef OPT_FLAGS
@@ -32,7 +24,7 @@ WERROR = -Werror
 endif
 
 CPPFLAGS = $(EXTRA_CPPFLAGS) -Isljit_src
-CFLAGS += $(OPT_FLAGS) $(WARN_FLAGS) $(WERROR)
+CFLAGS += $(COMPAT_FLAGS) $(OPT_FLAGS) $(WARN_FLAGS) $(WERROR)
 REGEX_CFLAGS += $(CFLAGS) -fshort-wchar
 LDFLAGS = $(EXTRA_LDFLAGS)
 
@@ -82,34 +74,34 @@ $(BINDIR)/regexMain.o : $(REGEXDIR)/regexMain.c $(BINDIR)/.keep $(SLJIT_HEADERS)
 $(BINDIR)/regexJIT.o : $(REGEXDIR)/regexJIT.c $(BINDIR)/.keep $(SLJIT_HEADERS) $(REGEXDIR)/regexJIT.h
 	$(CC) $(CPPFLAGS) $(REGEX_CFLAGS) -c -o $@ $(REGEXDIR)/regexJIT.c
 
-$(BINDIR)/sljit_test: $(BINDIR)/.keep $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c $(SLJIT_LIR_FILES) $(SLJIT_HEADERS) $(TESTDIR)/sljitConfigPre.h $(TESTDIR)/sljitConfigPost.h
+$(BINDIR)/sljit_test: $(BINDIR)/.keep $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c $(SLJIT_LIR_FILES) $(SLJIT_HEADERS) $(TESTDIR)/sljitConfigPre.h $(TESTDIR)/sljitConfigPost.h $(TESTDIR)/sljitTestCall.h $(TESTDIR)/sljitTestFloat.h $(TESTDIR)/sljitTestSimd.h
 	$(CC) $(CPPFLAGS) -DSLJIT_HAVE_CONFIG_PRE=1 -I$(TESTDIR) $(CFLAGS) $(LDFLAGS) $(BINDIR)/sljitMain.o $(TESTDIR)/sljitTest.c $(SRCDIR)/sljitLir.c -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/regex_test: $(BINDIR)/.keep $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(BINDIR)/regexMain.o $(BINDIR)/regexJIT.o $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 examples: $(EXAMPLE_TARGET)
 
 $(BINDIR)/first_program: $(EXAMPLEDIR)/first_program.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/first_program.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/first_program.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/branch: $(EXAMPLEDIR)/branch.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/branch.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/branch.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/loop: $(EXAMPLEDIR)/loop.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/loop.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/loop.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/array_access: $(EXAMPLEDIR)/array_access.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/array_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/array_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/func_call: $(EXAMPLEDIR)/func_call.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/func_call.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/func_call.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/struct_access: $(EXAMPLEDIR)/struct_access.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/struct_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/struct_access.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/temp_var: $(EXAMPLEDIR)/temp_var.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/temp_var.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/temp_var.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
 
 $(BINDIR)/brainfuck: $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/.keep $(BINDIR)/sljitLir.o
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(EXAMPLEDIR)/brainfuck.c $(BINDIR)/sljitLir.o -o $@ -lm -lpthread $(EXTRA_LIBS)

--- a/doc/tutorial/array_access.c
+++ b/doc/tutorial/array_access.c
@@ -5,10 +5,9 @@
 
 typedef long (SLJIT_FUNC *func_arr_t)(long *arr, long narr);
 
-static long SLJIT_FUNC print_num(long a)
+static void SLJIT_FUNC print_num(long a)
 {
 	printf("num = %ld\n", a);
-	return a + 1;
 }
 
 /*
@@ -27,26 +26,46 @@ long func(long *array, long narray)
 static int array_access(long *arr, long narr)
 {
 	void *code;
-	unsigned long len;
+	size_t len;
 	func_arr_t func;
+	struct sljit_label *loopstart;
+	struct sljit_jump *out;
 
 	/* Create a SLJIT compiler */
 	struct sljit_compiler *C = sljit_create_compiler(NULL, NULL);
 
-	sljit_emit_enter(C, 0, SLJIT_ARGS2(W, P, W),  1, 3, 0, 0, 0);
-	/*                  opt arg R  S  FR FS local_size */
-	sljit_emit_op2(C, SLJIT_XOR, SLJIT_S2, 0, SLJIT_S2, 0, SLJIT_S2, 0);				// S2 = 0
-	sljit_emit_op1(C, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, narr);                         // S1 = narr
-	struct sljit_label *loopstart = sljit_emit_label(C);								// loopstart:
-	struct sljit_jump *out = sljit_emit_cmp(C, SLJIT_GREATER_EQUAL, SLJIT_S2, 0, SLJIT_S1, 0);	// S2 >= a --> jump out
+	sljit_emit_enter(C, 0, SLJIT_ARGS2(W, P, W), 1, 3, 0, 0, 0);
+	/*                  opt arg                  R  S  FR FS local_size */
 
-	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM2(SLJIT_S0, SLJIT_S2), SLJIT_WORD_SHIFT);// R0 = (long *)S0[S2];
-	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, W), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));					// print_num(R0);
+	/* S2 = 0 */
+	sljit_emit_op2(C, SLJIT_XOR, SLJIT_S2, 0, SLJIT_S2, 0, SLJIT_S2, 0);
 
-	sljit_emit_op2(C, SLJIT_ADD, SLJIT_S2, 0, SLJIT_S2, 0, SLJIT_IMM, 1);						// S2 += 1
-	sljit_set_label(sljit_emit_jump(C, SLJIT_JUMP), loopstart);									// jump loopstart
-	sljit_set_label(out, sljit_emit_label(C));											// out:
-	sljit_emit_return(C, SLJIT_MOV, SLJIT_S1, 0);										// return RET
+	/* S1 = narr */
+	sljit_emit_op1(C, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, narr);
+
+	/* loopstart:              */
+	loopstart = sljit_emit_label(C);
+
+	/* S2 >= narr --> jumo out */
+	out = sljit_emit_cmp(C, SLJIT_GREATER_EQUAL, SLJIT_S2, 0, SLJIT_S1, 0);
+
+	/* R0 = (long *)S0[S2];    */
+	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM2(SLJIT_S0, SLJIT_S2), SLJIT_WORD_SHIFT);
+
+	/* print_num(R0)           */
+	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1V(W), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));
+
+	/* S2 += 1                 */
+	sljit_emit_op2(C, SLJIT_ADD, SLJIT_S2, 0, SLJIT_S2, 0, SLJIT_IMM, 1);
+
+	/* jump loopstart          */
+	sljit_set_label(sljit_emit_jump(C, SLJIT_JUMP), loopstart);
+
+	/* out:                    */
+	sljit_set_label(out, sljit_emit_label(C));
+
+	/* return S1               */
+	sljit_emit_return(C, SLJIT_MOV, SLJIT_S1, 0);
 
 	/* Generate machine code */
 	code = sljit_generate_code(C);
@@ -64,7 +83,7 @@ static int array_access(long *arr, long narr)
 	return 0;
 }
 
-int main()
+int main(void)
 {
 	long arr[8] = { 3, -10, 4, 6, 8, 12, 2000, 0 };
 	return array_access(arr, 8);

--- a/doc/tutorial/brainfuck.c
+++ b/doc/tutorial/brainfuck.c
@@ -111,7 +111,7 @@ static int loop_pop(struct sljit_label **loop_start, struct sljit_jump **loop_en
 	return 0;
 }
 
-static void *SLJIT_FUNC my_alloc(long size, long n)
+static void *SLJIT_FUNC my_alloc(size_t size, size_t n)
 {
 	return calloc(size, n);
 }
@@ -148,9 +148,11 @@ static void *compile(FILE *src, unsigned long *lcode)
 	int SP = SLJIT_S0;			/* bf SP */
 	int CELLS = SLJIT_S1;		/* bf array */
 
-	sljit_emit_enter(C, 0, SLJIT_ARGS2(VOID, W, W), 2, 2, 0, 0, 0);								/* opt arg R  S  FR FS local_size */
+	sljit_emit_enter(C, 0, SLJIT_ARGS2V(W, W), 2, 2, 0, 0, 0);
+	/*                  opt arg                R  S  FR FS local_size */
 
-	sljit_emit_op2(C, SLJIT_XOR, SP, 0, SP, 0, SP, 0);						/* SP = 0 */
+	/* SP = 0 */
+	sljit_emit_op2(C, SLJIT_XOR, SP, 0, SP, 0, SP, 0);
 
 	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, BF_CELL_SIZE);
 	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, 1);

--- a/doc/tutorial/struct_access.c
+++ b/doc/tutorial/struct_access.c
@@ -10,7 +10,7 @@ struct point_st {
 	char d;
 };
 
-typedef long (SLJIT_FUNC *point_func_t)(struct point_st *point);;
+typedef long (SLJIT_FUNC *point_func_t)(struct point_st *point);
 
 static long SLJIT_FUNC print_num(long a)
 {
@@ -45,21 +45,26 @@ static int struct_access()
 	struct sljit_compiler *C = sljit_create_compiler(NULL, NULL);
 
 	sljit_emit_enter(C, 0, SLJIT_ARGS1(W, W), 1, 1, 0, 0, 0);
-	/*                  opt arg R  S  FR FS local_size */
+	/*                  opt arg               R  S  FR FS local_size */
 
-	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, x));	// S0->x --> R0
-	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));								// print_num(R0);
+	/* S0->x --> R0; print_num(R0) */
+	sljit_emit_op1(C, SLJIT_MOV, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, x));
+	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));
 
-	sljit_emit_op1(C, SLJIT_MOV_S32, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, y));	// S0->y --> R0
-	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));								// print_num(R0);
+	/* S0->y --> R0; print_num(R0) */
+	sljit_emit_op1(C, SLJIT_MOV_S32, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, y));
+	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));
 
-	sljit_emit_op1(C, SLJIT_MOV_S16, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, z));	// S0->z --> R0
-	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));								// print_num(R0);
+	/* S0->z --> R0; print_num(R0) */
+	sljit_emit_op1(C, SLJIT_MOV_S16, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, z));
+	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));
 
-	sljit_emit_op1(C, SLJIT_MOV_S8, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, d));	// S0->d --> R0
-	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));								// print_num(R0);
+	/* S0->d --> R0; print_num(R0) */
+	sljit_emit_op1(C, SLJIT_MOV_S8, SLJIT_R0, 0, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, d));
+	sljit_emit_icall(C, SLJIT_CALL, SLJIT_ARGS1(W, P), SLJIT_IMM, SLJIT_FUNC_ADDR(print_num));
 
-	sljit_emit_return(C, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, x));				// return S0->x
+	/* return S0->x */
+	sljit_emit_return(C, SLJIT_MOV, SLJIT_MEM1(SLJIT_S0), SLJIT_OFFSETOF(struct point_st, x));
 
 	/* Generate machine code */
 	code = sljit_generate_code(C);

--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -1995,7 +1995,7 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_fset64(struct sljit_compi
 	if (SLJIT_UNLIKELY(!!compiler->verbose)) {
 		fprintf(compiler->verbose, "  fset64 ");
 		sljit_verbose_freg(compiler, freg);
-		fprintf(compiler->verbose, ", %lf\n", value);
+		fprintf(compiler->verbose, ", %f\n", value);
 	}
 #endif
 	CHECK_RETURN_OK;

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -3056,7 +3056,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 
 		inst = emit_x86_instruction(compiler, 2 | EX86_PREF_66 | EX86_SSE2_OP2, 0, 0, dst_r, 0);
 		inst[0] = GROUP_0F;
-		// Same as PSRLD_x / PSRLQ_x
+		/* Same as PSRLD_x / PSRLQ_x */
 		inst[1] = (op & SLJIT_32) ? PSLLD_x_i8 : PSLLQ_x_i8;
 
 		if (GET_OPCODE(op) == SLJIT_ABS_F64) {


### PR DESCRIPTION
While `-pedantic` is all that is needed together with an `-std` version; adding `-Wpedantic` allows for some "extra" and has been supported by `clang` for  a long while as well as by `gcc >= 4.8`.

The non C89 compliant parts of `s390x` could be addressed later, but are unlikely to be ever needed under the currently supported environments; the same goes for `ppc` where using a `void *` for a function is not valid C (because pointers to data and code can have different sizes), but is required for POSIX, and all systems using that CPU usually conform to that. 