### PR TITLE
Fix build on older macOS

### DIFF
--- a/sljit_src/allocator_src/sljitExecAllocatorApple.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorApple.c
@@ -41,9 +41,10 @@
 #include <sys/utsname.h>
 #include <stdlib.h>
 
-#define SLJIT_MAP_JIT	(get_map_jit_flag())
 #define SLJIT_UPDATE_WX_FLAGS(from, to, enable_exec)
 
+#ifdef MAP_JIT
+#define SLJIT_MAP_JIT	(get_map_jit_flag())
 static SLJIT_INLINE int get_map_jit_flag(void)
 {
 	size_t page_size;
@@ -70,6 +71,9 @@ static SLJIT_INLINE int get_map_jit_flag(void)
 	}
 	return map_jit_flag;
 }
+#else /* !defined(MAP_JIT) */
+#define SLJIT_MAP_JIT	(0)
+#endif
 
 #elif defined(SLJIT_CONFIG_ARM) && SLJIT_CONFIG_ARM
 


### PR DESCRIPTION
The headers on some older macOS versions don't define MAP_JIT at all.