### PR TITLE
Fix locking region in sjlit_malloc_exec

### DIFF
--- a/sljit_src/allocator_src/sljitExecAllocatorCore.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorCore.c
@@ -235,12 +235,12 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 		header->size = chunk_size;
 		next_header = AS_BLOCK_HEADER(header, chunk_size);
 	}
-	SLJIT_ALLOCATOR_UNLOCK();
 	next_header->size = 1;
 	next_header->prev_size = chunk_size;
 #ifdef SLJIT_HAS_EXECUTABLE_OFFSET
 	next_header->executable_offset = executable_offset;
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
+	SLJIT_ALLOCATOR_UNLOCK();
 	return MEM_START(header);
 }
 


### PR DESCRIPTION
The locked section needs to extend until we are done modifying internal block offsets and sizes, otherwise we risk running into data corruption in a multi-threaded context.

This bug was introduced in 7de0fee9a7376b33e31a3903487cd9933da3a606

See: https://github.com/PCRE2Project/pcre2/issues/402