### PR TITLE
loongarch: Implement ll/sc support for atomic operations

### DIFF
--- a/sljit_src/sljitNativeMIPS_common.c
+++ b/sljit_src/sljitNativeMIPS_common.c
@@ -4231,7 +4231,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_atomic_load(struct sljit_compiler 
 #if (defined SLJIT_CONFIG_MIPS_64 && SLJIT_CONFIG_MIPS_64)
 		ins = LLD;
 		break;
-#endif /* SLJIT_CONFIG_RISCV_64 */
+#endif /* SLJIT_CONFIG_MIPS_64 */
 	case SLJIT_MOV_S32:
 	case SLJIT_MOV32:
 		ins = LL;


### PR DESCRIPTION
Implement ll/sc for loongarch atomic load & store, also fix amcas bugs.
Tested under 3C5000 and 3A6000 (with amcas support).