### PR TITLE
x86: avoid SIGILL in CPUs with AVX but without AVX2

### DIFF
--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -3900,7 +3900,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 		}
 	}
 
-	if (use_vex && elem_size >= 2) {
+	if ((cpu_feature_list & CPU_FEATURE_AVX2) && use_vex && elem_size >= 2) {
 #if (defined SLJIT_CONFIG_X86_32 && SLJIT_CONFIG_X86_32)
 		op = VPBROADCASTD_x_xm;
 #else /* !SLJIT_CONFIG_X86_32 */


### PR DESCRIPTION
Fix a SIGILL crash in machines with Intel's Sandy Bridge, Ivy Bridge as well as the three first generation of AMD Bulldozer and other equivalent CPUs