### PR TITLE
riscv: only enable SIMD if supported by system

### DIFF
--- a/sljit_src/sljitNativeRISCV_common.c
+++ b/sljit_src/sljitNativeRISCV_common.c
@@ -697,7 +697,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_has_cpu_feature(sljit_s32 feature_type)
 	case SLJIT_HAS_COPY_F64:
 #endif /* !SLJIT_CONFIG_RISCV_64 */
 	case SLJIT_HAS_ATOMIC:
+#ifdef __riscv_vector
 	case SLJIT_HAS_SIMD:
+#endif
 		return 1;
 	default:
 		return 0;


### PR DESCRIPTION
Avoid SIGILL when the CPU/OS/toolchain doesn't support the vector extension and that is fairly common in currently available systems.