### PR TITLE
Emit brk #0xf000 for breakpoint opcode on arm64

### DIFF
--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -1548,7 +1548,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 	op = GET_OPCODE(op);
 	switch (op) {
 	case SLJIT_BREAKPOINT:
-		return push_inst(compiler, BRK);
+		return push_inst(compiler, BRK | (0xf000 << 5));
 	case SLJIT_NOP:
 		return push_inst(compiler, NOP);
 	case SLJIT_LMUL_UW:


### PR DESCRIPTION
Implement SLJIT_BREAKPOINT with the same instruction emitted by MSVC for the __debugbreak intrinsic (brk #0xf000) and by Clang for __builtin_debugtrap. On Windows, this triggers a breakpoint exception just as int3 does on x86. The previously emitted instruction (brk #0) triggers an illegal instruction exception instead.

LLDB also has special handling for this brk variant on Windows and macOS, automatically advancing to the next instruction so execution can be easily continued.

Fixes #266