### PR TITLE
Enable -Wshadow warning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ OPT_FLAGS = -O2
 endif
 
 ifndef WARN_FLAGS
-WARN_FLAGS = -Wall -Wextra -Wconversion -Wsign-compare -Wdeclaration-after-statement -Wunused-function
+WARN_FLAGS = -Wall -Wextra -Wconversion -Wsign-compare -Wdeclaration-after-statement -Wunused-function -Wshadow
 endif
 
 ifndef WERROR

--- a/sljit_src/allocator_src/sljitExecAllocatorCore.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorCore.c
@@ -49,9 +49,9 @@
        n - The size of the previous block.
 
    Using these size values we can go forward or backward on the block chain.
-   The unused blocks are stored in a chain list pointed by free_blocks. This
-   list is useful if we need to find a suitable memory area when the allocator
-   is called.
+   The unused blocks are stored in a chain list pointed by sljit_free_blocks.
+   This list is useful if we need to find a suitable memory area when the
+   allocator is called.
 
    When a block is freed, the new free block is connected to its adjacent free
    blocks if possible.
@@ -115,20 +115,20 @@ struct free_block {
 #define ALIGN_SIZE(size)	(((size) + sizeof(struct block_header) + 7u) & ~(sljit_uw)7)
 #define CHUNK_EXTRA_SIZE	(sizeof(struct block_header) + CHUNK_HEADER_SIZE)
 
-static struct free_block* free_blocks;
-static sljit_uw allocated_size;
-static sljit_uw total_size;
+static struct free_block* sljit_free_blocks;
+static sljit_uw sljit_allocated_size;
+static sljit_uw sljit_total_size;
 
 static SLJIT_INLINE void sljit_insert_free_block(struct free_block *free_block, sljit_uw size)
 {
 	free_block->header.size = 0;
 	free_block->size = size;
 
-	free_block->next = free_blocks;
+	free_block->next = sljit_free_blocks;
 	free_block->prev = NULL;
-	if (free_blocks)
-		free_blocks->prev = free_block;
-	free_blocks = free_block;
+	if (sljit_free_blocks)
+		sljit_free_blocks->prev = free_block;
+	sljit_free_blocks = free_block;
 }
 
 static SLJIT_INLINE void sljit_remove_free_block(struct free_block *free_block)
@@ -139,8 +139,8 @@ static SLJIT_INLINE void sljit_remove_free_block(struct free_block *free_block)
 	if (free_block->prev)
 		free_block->prev->next = free_block->next;
 	else {
-		SLJIT_ASSERT(free_blocks == free_block);
-		free_blocks = free_block->next;
+		SLJIT_ASSERT(sljit_free_blocks == free_block);
+		sljit_free_blocks = free_block->next;
 	}
 }
 
@@ -166,7 +166,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 	size = ALIGN_SIZE(size);
 
 	SLJIT_ALLOCATOR_LOCK();
-	free_block = free_blocks;
+	free_block = sljit_free_blocks;
 	while (free_block) {
 		if (free_block->size >= size) {
 			chunk_size = free_block->size;
@@ -186,7 +186,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 				header = (struct block_header*)free_block;
 				size = chunk_size;
 			}
-			allocated_size += size;
+			sljit_allocated_size += size;
 			header->size = size;
 			SLJIT_ALLOCATOR_UNLOCK();
 			return MEM_START(header);
@@ -207,7 +207,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
 
 	chunk_size -= CHUNK_EXTRA_SIZE;
-	total_size += chunk_size;
+	sljit_total_size += chunk_size;
 
 	header = (struct block_header*)(((sljit_u8*)chunk_header) + CHUNK_HEADER_SIZE);
 
@@ -218,7 +218,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 
 	if (chunk_size > size + 64) {
 		/* Cut the allocated space into a free and a used block. */
-		allocated_size += size;
+		sljit_allocated_size += size;
 		header->size = size;
 		chunk_size -= size;
 
@@ -231,7 +231,7 @@ SLJIT_API_FUNC_ATTRIBUTE void* sljit_malloc_exec(sljit_uw size)
 		next_header = AS_BLOCK_HEADER(free_block, chunk_size);
 	} else {
 		/* All space belongs to this allocation. */
-		allocated_size += chunk_size;
+		sljit_allocated_size += chunk_size;
 		header->size = chunk_size;
 		next_header = AS_BLOCK_HEADER(header, chunk_size);
 	}
@@ -254,7 +254,7 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void *ptr)
 #ifdef SLJIT_HAS_EXECUTABLE_OFFSET
 	header = AS_BLOCK_HEADER(header, -header->executable_offset);
 #endif /* SLJIT_HAS_EXECUTABLE_OFFSET */
-	allocated_size -= header->size;
+	sljit_allocated_size -= header->size;
 
 	SLJIT_UPDATE_WX_FLAGS(NULL, NULL, 0);
 
@@ -282,9 +282,9 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_exec(void *ptr)
 
 	/* The whole chunk is free. */
 	if (SLJIT_UNLIKELY(!free_block->header.prev_size && header->size == 1)) {
-		/* If this block is freed, we still have (allocated_size / 2) free space. */
-		if (total_size - free_block->size > (allocated_size * 3 / 2)) {
-			total_size -= free_block->size;
+		/* If this block is freed, we still have (sljit_allocated_size / 2) free space. */
+		if (sljit_total_size - free_block->size > (sljit_allocated_size * 3 / 2)) {
+			sljit_total_size -= free_block->size;
 			sljit_remove_free_block(free_block);
 			free_chunk(free_block, free_block->size + CHUNK_EXTRA_SIZE);
 		}
@@ -302,19 +302,19 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_free_unused_memory_exec(void)
 	SLJIT_ALLOCATOR_LOCK();
 	SLJIT_UPDATE_WX_FLAGS(NULL, NULL, 0);
 
-	free_block = free_blocks;
+	free_block = sljit_free_blocks;
 	while (free_block) {
 		next_free_block = free_block->next;
 		if (!free_block->header.prev_size &&
 				AS_BLOCK_HEADER(free_block, free_block->size)->size == 1) {
-			total_size -= free_block->size;
+			sljit_total_size -= free_block->size;
 			sljit_remove_free_block(free_block);
 			free_chunk(free_block, free_block->size + CHUNK_EXTRA_SIZE);
 		}
 		free_block = next_free_block;
 	}
 
-	SLJIT_ASSERT(total_size || (!total_size && !free_blocks));
+	SLJIT_ASSERT(sljit_total_size || (!sljit_total_size && !sljit_free_blocks));
 	SLJIT_UPDATE_WX_FLAGS(NULL, NULL, 1);
 	SLJIT_ALLOCATOR_UNLOCK();
 }

--- a/sljit_src/sljitNativeS390X.c
+++ b/sljit_src/sljitNativeS390X.c
@@ -169,10 +169,10 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 	switch (type) {
 	case SLJIT_EQUAL:
 		if (SLJIT_ADD_SUB_NO_COMPARE(compiler->status_flags_state)) {
-			sljit_s32 type = GET_FLAG_TYPE(compiler->status_flags_state);
-			if (type >= SLJIT_SIG_LESS && type <= SLJIT_SIG_LESS_EQUAL)
+			sljit_s32 flag_type = GET_FLAG_TYPE(compiler->status_flags_state);
+			if (flag_type >= SLJIT_SIG_LESS && flag_type <= SLJIT_SIG_LESS_EQUAL)
 				return cc0;
-			if (type == SLJIT_OVERFLOW)
+			if (flag_type == SLJIT_OVERFLOW)
 				return (cc0 | cc3);
 			return (cc0 | cc2);
 		}
@@ -185,10 +185,10 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 
 	case SLJIT_NOT_EQUAL:
 		if (SLJIT_ADD_SUB_NO_COMPARE(compiler->status_flags_state)) {
-			sljit_s32 type = GET_FLAG_TYPE(compiler->status_flags_state);
-			if (type >= SLJIT_SIG_LESS && type <= SLJIT_SIG_LESS_EQUAL)
+			sljit_s32 flag_type = GET_FLAG_TYPE(compiler->status_flags_state);
+			if (flag_type >= SLJIT_SIG_LESS && flag_type <= SLJIT_SIG_LESS_EQUAL)
 				return (cc1 | cc2 | cc3);
-			if (type == SLJIT_OVERFLOW)
+			if (flag_type == SLJIT_OVERFLOW)
 				return (cc1 | cc2);
 			return (cc1 | cc3);
 		}
@@ -333,7 +333,7 @@ static SLJIT_INLINE int have_facility_static(facility_bit x)
 	return 0;
 }
 
-static SLJIT_INLINE unsigned long get_hwcap()
+static SLJIT_INLINE unsigned long get_hwcap(void)
 {
 	static unsigned long hwcap = 0;
 	if (SLJIT_UNLIKELY(!hwcap)) {
@@ -343,7 +343,7 @@ static SLJIT_INLINE unsigned long get_hwcap()
 	return hwcap;
 }
 
-static SLJIT_INLINE int have_stfle()
+static SLJIT_INLINE int have_stfle(void)
 {
 	if (have_facility_static(STORE_FACILITY_LIST_EXTENDED_FACILITY))
 		return 1;
@@ -2243,7 +2243,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compile
 		}
 		/* STORE and STORE IMMEDIATE */
 		if ((dst & SLJIT_MEM) && (FAST_IS_REG(src) || src == SLJIT_IMM)) {
-			struct addr mem;
 			sljit_gpr reg = FAST_IS_REG(src) ? gpr(src) : tmp0;
 
 			if (src == SLJIT_IMM) {
@@ -2276,7 +2275,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compile
 		#undef LEVAL
 		/* MOVE CHARACTERS */
 		if ((dst & SLJIT_MEM) && (src & SLJIT_MEM)) {
-			struct addr mem;
 			FAIL_IF(make_addr_bxy(compiler, &mem, src, srcw, tmp1));
 			switch (opcode) {
 			case SLJIT_MOV_U8:


### PR DESCRIPTION
PCRE2 uses `-Wshadow`, so it's helpful if the sljit code does as well.

Some errors seem to have crept in to the Mac-only (or rather, ARM-only) code which wasn't noticed until I tried a PCRE2 build on that platform, in one of the build configurations using `-Wshadow`.