### PR TITLE
Fix sljit_emit_icall on Linux x86_64

### DIFF
--- a/sljit_src/sljitNativeX86_64.c
+++ b/sljit_src/sljitNativeX86_64.c
@@ -805,7 +805,7 @@ static sljit_s32 call_with_args(struct sljit_compiler *compiler, sljit_s32 arg_t
 	if (word_arg_count == 0)
 		return SLJIT_SUCCESS;
 
-	if (word_arg_count >= 3) {
+	if (word_arg_count >= 3 || src == SLJIT_R2) {
 		if (src == SLJIT_R2)
 			*src_ptr = TMP_REG1;
 		EMIT_MOV(compiler, TMP_REG1, 0, SLJIT_R2, 0);


### PR DESCRIPTION
In current version SLJIT, sljit_emit_icall only save "RDI" if word_arg_count >= 3. But RDI is the first argument according to Linux x86_64 calling convention,

in other words, below code will cause SegFault on current version SLJIT.

```c
	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 10);
	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, 16);
	sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, SLJIT_FUNC_ADDR(func2));
	sljit_emit_icall(compiler, SLJIT_CALL, SLJIT_ARGS2(W, W, W), SLJIT_R2, 0);
```

BTW sljit  failed on windows in test_float13, with large stack test. 
Is it known issue? Should we decrease the SLJIT_MAX_LOCAL_SIZE on windows?