### PR TITLE
loongarch: Update toolchain and minor code style change

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,7 +49,7 @@ jobs:
               target: riscv64-linux-user
               name: qemu-riscv64
           - name: riscv64
-            toolchain: 
+            toolchain:
               url: https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2024.05-1.tar.xz
               name: riscv64-lp64d--glibc--stable-2024.05-1.tar.xz
               CC: riscv64-buildroot-linux-gnu-gcc-13.3.0.br_real
@@ -77,8 +77,8 @@ jobs:
               name: qemu-riscv32
           - name: loongarch64
             toolchain:
-              url: https://github.com/loongson/build-tools/releases/download/2024.11.01/x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
-              name: x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
+              url: https://github.com/loongson/build-tools/releases/download/2025.02.21/x86_64-cross-tools-loongarch64-binutils_2.44-gcc_14.2.0-glibc_2.41.tar.xz
+              name: x86_64-cross-tools-loongarch64-binutils_2.44-gcc_14.2.0-glibc_2.41.tar.xz
               CC: loongarch64-unknown-linux-gnu-gcc-14.2.0
               CFLAGS: -march=la464
             qemu:

--- a/sljit_src/sljitNativeLOONGARCH_64.c
+++ b/sljit_src/sljitNativeLOONGARCH_64.c
@@ -3997,7 +3997,7 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_s32 op, sljit
 	switch (GET_OPCODE(op)) {
 	case SLJIT_MOV_U8:
 		inst = (sljit_ins*)addr;
-		SLJIT_ASSERT((inst[0] & 0xffc00000) == ADDI_D);
+		SLJIT_ASSERT((inst[0] & OPC_2RI12(0xb)) == ADDI_D);
 
 		if (new_constant & 0x100)
 			new_constant |= 0xf00;
@@ -4014,11 +4014,11 @@ SLJIT_API_FUNC_ATTRIBUTE void sljit_set_const(sljit_uw addr, sljit_s32 op, sljit
 	case SLJIT_MOV32:
 	case SLJIT_MOV_S32:
 		inst = (sljit_ins *)addr;
-		SLJIT_ASSERT((inst[0] & 0xfe000000) == LU12I_W && (inst[1] & 0xffc00000) == ORI);
+		SLJIT_ASSERT((inst[0] & OPC_1RI20(0xa)) == LU12I_W && (inst[1] & OPC_2RI12(0xe)) == ORI);
 
 		SLJIT_UPDATE_WX_FLAGS(inst, inst + 2, 0);
-		inst[0] = (inst[0] & 0xfe00001f) | (sljit_ins)((new_constant >> 7) & 0x1ffffe0);
-		inst[1] = (inst[1] & 0xffc003ff) | (sljit_ins)((new_constant & 0xfff) << 10);
+		inst[0] = (inst[0] & (OPC_1RI20(0xa) | 0x1f)) | (sljit_ins)((new_constant >> 7) & 0x1ffffe0);
+		inst[1] = (inst[1] & (OPC_2RI12(0xe) | 0x3ff)) | (sljit_ins)((new_constant & 0xfff) << 10);
 		SLJIT_UPDATE_WX_FLAGS(inst, inst + 2, 1);
 		inst = (sljit_ins *)SLJIT_ADD_EXEC_OFFSET(inst, executable_offset);
 		SLJIT_CACHE_FLUSH(inst, inst + 2);


### PR DESCRIPTION
Update toolchain to the lastest 2025.02.21 version & some minor code style change to maintain the consistency of codebase.