### PR TITLE
Fix Docusaurus URL configuration

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
   title: 'SLJIT',
   tagline: 'Platform-independent low-level JIT compiler',
 
-  url: 'https://zherczeg.github.com',
+  url: 'https://zherczeg.github.io',
   baseUrl: '/sljit/',
 
   organizationName: 'zherczeg',


### PR DESCRIPTION
Tried to test the deployment to a `gh-pages` branch and noticed this small mistake in the configuration.