### PR TITLE
Silence clang compiler warning: unannotated fall-through between switch labels 

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -970,6 +970,28 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_sw sljit_exec_offset(void *code);
 
 #endif /* !SLJIT_COMPILE_ASSERT */
 
+#ifndef SLJIT_FALLTHROUGH
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#if defined(__has_c_attribute)
+#if __has_c_attribute(__fallthrough__)
+#define SLJIT_FALLTHROUGH [[__fallthrough__]]
+#endif
+#endif
+#endif
+
+#if defined(__has_attribute) && !defined(SLJIT_FALLTHROUGH)
+#if __has_attribute(__fallthrough__)
+#define SLJIT_FALLTHROUGH __attribute__((__fallthrough__))
+#endif
+#endif
+
+#ifndef SLJIT_FALLTHROUGH
+#define SLJIT_FALLTHROUGH do {} while(0)
+#endif
+
+#endif /* !SLJIT_FALLTHROUGH */
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sljit_src/sljitLir.c
+++ b/sljit_src/sljitLir.c
@@ -2805,7 +2805,7 @@ static SLJIT_INLINE CHECK_RETURN_TYPE check_sljit_emit_mem(struct sljit_compiler
 	case SLJIT_MOV_P:
 	case SLJIT_MOV:
 		allowed_flags |= SLJIT_MEM_ALIGNED_32;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_U32:
 	case SLJIT_MOV_S32:
 	case SLJIT_MOV32:

--- a/sljit_src/sljitNativeARM_32.c
+++ b/sljit_src/sljitNativeARM_32.c
@@ -1820,7 +1820,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			src2 = TMP_REG2;
 		} else
 			compiler->shift_imm = (sljit_uw)(-(sljit_sw)compiler->shift_imm) & 0x1f;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ROTR:
 		shift_type = 3;
@@ -3089,7 +3089,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x20000000;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_LESS:
 		return 0x30000000;
@@ -3097,7 +3097,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x30000000;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_GREATER_EQUAL:
 		return 0x20000000;
@@ -3132,7 +3132,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x10000000;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_UNORDERED:
 		return 0x60000000;
@@ -3140,7 +3140,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x00000000;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ORDERED:
 		return 0x70000000;

--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -951,7 +951,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 				FAIL_IF(push_inst(compiler, (ORN ^ inv_bits) | RD(dst) | RN(TMP_ZERO) | RM(reg)));
 				goto set_flags;
 			}
-			/* fallthrough */
+			SLJIT_FALLTHROUGH; /* fallthrough */
 		case SLJIT_OR:
 			inst_bits = logical_imm(imm, LOGICAL_IMM_CHECK | ((flags & INT_OP) ? 16 : 32));
 			if (!inst_bits)
@@ -1060,7 +1060,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 		SLJIT_ASSERT(!(flags & SET_FLAGS) && arg1 == TMP_REG1);
 		if (dst == arg2)
 			return SLJIT_SUCCESS;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_U32:
 		SLJIT_ASSERT(!(flags & SET_FLAGS) && arg1 == TMP_REG1);
 		return push_inst(compiler, (MOV ^ W_OP) | RD(dst) | RM(arg2));
@@ -1145,7 +1145,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 	case SLJIT_ROTL:
 		FAIL_IF(push_inst(compiler, (SUB ^ inv_bits) | RD(TMP_REG2) | RN(TMP_ZERO) | RM(arg2)));
 		arg2 = TMP_REG2;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_ROTR:
 		return push_inst(compiler, (RORV ^ inv_bits) | RD(dst) | RN(arg1) | RM(arg2));
 	case SLJIT_MULADD:
@@ -2316,7 +2316,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x3;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_LESS:
 		return 0x2;
@@ -2324,7 +2324,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x2;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_GREATER_EQUAL:
 		return 0x3;
@@ -2359,7 +2359,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x0;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_UNORDERED:
 		return 0x7;
@@ -2367,7 +2367,7 @@ static sljit_ins get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ORDERED:
 		return 0x6;
@@ -2792,19 +2792,19 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem_update(struct sljit_compiler *
 		break;
 	case SLJIT_MOV_S8:
 		sign = 1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_U8:
 		inst = STURBI | (MEM_SIZE_SHIFT(BYTE_SIZE) << 30) | 0x400;
 		break;
 	case SLJIT_MOV_S16:
 		sign = 1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_U16:
 		inst = STURBI | (MEM_SIZE_SHIFT(HALF_SIZE) << 30) | 0x400;
 		break;
 	case SLJIT_MOV_S32:
 		sign = 1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_U32:
 	case SLJIT_MOV32:
 		inst = STURBI | (MEM_SIZE_SHIFT(INT_SIZE) << 30) | 0x400;

--- a/sljit_src/sljitNativeARM_64.c
+++ b/sljit_src/sljitNativeARM_64.c
@@ -905,7 +905,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 			if (flags & ARG1_IMM)
 				break;
 			imm = -imm;
-			/* Fall through. */
+			SLJIT_FALLTHROUGH; /* fallthrough */
 		case SLJIT_ADD:
 			if (op != SLJIT_SUB)
 				compiler->status_flags_state = SLJIT_CURRENT_FLAGS_ADD;

--- a/sljit_src/sljitNativeARM_T2_32.c
+++ b/sljit_src/sljitNativeARM_T2_32.c
@@ -1042,7 +1042,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 				return push_inst32(compiler, ASR_WI | (flags & SET_FLAGS) | RD4(dst) | RM4(reg) | IMM5(imm));
 			case SLJIT_ROTL:
 				imm = (imm ^ 0x1f) + 1;
-				/* fallthrough */
+				SLJIT_FALLTHROUGH; /* fallthrough */
 			default: /* SLJIT_ROTR */
 				return push_inst32(compiler, ROR_WI | RD4(dst) | RM4(reg) | IMM5(imm));
 			}
@@ -1178,7 +1178,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 		reg = (arg2 == TMP_REG1) ? TMP_REG1 : TMP_REG2;
 		FAIL_IF(push_inst32(compiler, ANDI | RD4(reg) | RN4(arg2) | 0x1f));
 		arg2 = (sljit_uw)reg;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_SHL:
 		if (dst == (sljit_s32)arg1 && IS_2_LO_REGS(dst, arg2))
 			return push_inst16(compiler, LSLS | RD3(dst) | RN3(arg2));
@@ -1187,7 +1187,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 		reg = (arg2 == TMP_REG1) ? TMP_REG1 : TMP_REG2;
 		FAIL_IF(push_inst32(compiler, ANDI | RD4(reg) | RN4(arg2) | 0x1f));
 		arg2 = (sljit_uw)reg;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_LSHR:
 		if (dst == (sljit_s32)arg1 && IS_2_LO_REGS(dst, arg2))
 			return push_inst16(compiler, LSRS | RD3(dst) | RN3(arg2));
@@ -1196,7 +1196,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 		reg = (arg2 == TMP_REG1) ? TMP_REG1 : TMP_REG2;
 		FAIL_IF(push_inst32(compiler, ANDI | RD4(reg) | RN4(arg2) | 0x1f));
 		arg2 = (sljit_uw)reg;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_ASHR:
 		if (dst == (sljit_s32)arg1 && IS_2_LO_REGS(dst, arg2))
 			return push_inst16(compiler, ASRS | RD3(dst) | RN3(arg2));
@@ -1205,7 +1205,7 @@ static sljit_s32 emit_op_imm(struct sljit_compiler *compiler, sljit_s32 flags, s
 		reg = (arg2 == TMP_REG1) ? TMP_REG1 : TMP_REG2;
 		FAIL_IF(push_inst32(compiler, RSB_WI | RD4(reg) | RN4(arg2) | 0));
 		arg2 = (sljit_uw)reg;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_ROTR:
 		if (dst == (sljit_s32)arg1 && IS_2_LO_REGS(dst, arg2))
 			return push_inst16(compiler, RORS | RD3(dst) | RN3(arg2));
@@ -2653,7 +2653,7 @@ static sljit_uw get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x2;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_LESS:
 		return 0x3;
@@ -2661,7 +2661,7 @@ static sljit_uw get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_ADD)
 			return 0x3;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_GREATER_EQUAL:
 		return 0x2;
@@ -2696,7 +2696,7 @@ static sljit_uw get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_UNORDERED:
 		return 0x6;
@@ -2704,7 +2704,7 @@ static sljit_uw get_cc(struct sljit_compiler *compiler, sljit_s32 type)
 	case SLJIT_NOT_OVERFLOW:
 		if (!(compiler->status_flags_state & (SLJIT_CURRENT_FLAGS_ADD | SLJIT_CURRENT_FLAGS_SUB)))
 			return 0x0;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ORDERED:
 		return 0x7;

--- a/sljit_src/sljitNativeLOONGARCH_64.c
+++ b/sljit_src/sljitNativeLOONGARCH_64.c
@@ -3938,7 +3938,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 
 	case SLJIT_MOV32:
 		mem_flags = INT_DATA;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_S32:
 		PTR_FAIL_IF(push_inst(compiler, LU12I_W | RD(dst_r) | (sljit_ins)((init_value >> 7) & 0x1ffffe0)));
 		PTR_FAIL_IF(push_inst(compiler, ORI | RD(dst_r) | RJ(dst_r) | IMM_I12(init_value)));

--- a/sljit_src/sljitNativeMIPS_common.c
+++ b/sljit_src/sljitNativeMIPS_common.c
@@ -2181,7 +2181,7 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 			FAIL_IF(push_inst(compiler, SELECT_OP(DSUBU, SUBU) | SA(0) | T(src2) | D(TMP_REG2), DR(TMP_REG2)));
 			src2 = TMP_REG2;
 		}
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ROTR:
 		EMIT_SHIFT(DROTR, DROTR32, ROTR, DROTRV, ROTRV);
@@ -2648,7 +2648,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2(struct sljit_compiler *compile
 		if ((src1 == SLJIT_IMM && src1w == -1) || (src2 == SLJIT_IMM && src2w == -1)) {
 			return emit_op(compiler, op, flags | CUMULATIVE_OP | IMM_OP, dst, dstw, src1, src1w, src2, src2w);
 		}
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_AND:
 	case SLJIT_OR:
 		return emit_op(compiler, op, flags | CUMULATIVE_OP | LOGICAL_OP | IMM_OP, dst, dstw, src1, src1w, src2, src2w);
@@ -4423,7 +4423,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 #if (defined(SLJIT_CONFIG_MIPS_64) && SLJIT_CONFIG_MIPS_64)
 	case SLJIT_MOV32:
 		mem_flags = INT_DATA;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_S32:
 		PTR_FAIL_IF(push_inst(compiler, LUI | T(dst_r) | IMM(init_value >> 16), DR(dst_r)));
 		PTR_FAIL_IF(push_inst(compiler, ORI | S(dst_r) | T(dst_r) | IMM(init_value), DR(dst_r)));

--- a/sljit_src/sljitNativePPC_common.c
+++ b/sljit_src/sljitNativePPC_common.c
@@ -1704,7 +1704,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compile
 #if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
 		op |= SLJIT_32;
 #endif /* SLJIT_CONFIG_PPC_64 */
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_REV:
 	case SLJIT_REV_U16:
 	case SLJIT_REV_S16:
@@ -1946,7 +1946,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op2(struct sljit_compiler *compile
 		if (src1 == SLJIT_IMM && src1w == -1) {
 			return emit_op(compiler, GET_OPCODE(op), flags | ALT_FORM4, dst, dstw, TMP_REG1, 0, src2, src2w);
 		}
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_AND:
 	case SLJIT_OR:
 		/* Commutative unsigned operations. */
@@ -2528,7 +2528,7 @@ static sljit_ins get_bo_bi_flags(struct sljit_compiler *compiler, sljit_s32 type
 	case SLJIT_NOT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_SUB)
 			return (4 << 21) | (2 << 16);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_EQUAL:
 	case SLJIT_ATOMIC_STORED:
@@ -2537,7 +2537,7 @@ static sljit_ins get_bo_bi_flags(struct sljit_compiler *compiler, sljit_s32 type
 	case SLJIT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_SUB)
 			return (12 << 21) | (2 << 16);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_NOT_EQUAL:
 	case SLJIT_ATOMIC_NOT_STORED:
@@ -3323,7 +3323,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 #if (defined SLJIT_CONFIG_PPC_64 && SLJIT_CONFIG_PPC_64)
 	case SLJIT_MOV32:
 		mem_flags = INT_DATA;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_S32:
 		PTR_FAIL_IF(push_inst(compiler, ADDIS | D(dst_r) | A(0) | IMM(init_value >> 16)));
 		PTR_FAIL_IF(push_inst(compiler, ORI | S(dst_r) | A(dst_r) | IMM(init_value)));

--- a/sljit_src/sljitNativePPC_common.c
+++ b/sljit_src/sljitNativePPC_common.c
@@ -2343,7 +2343,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fop1(struct sljit_compiler *compil
 			FAIL_IF(push_inst(compiler, FRSP | FD(dst_r) | FB(src)));
 			break;
 		}
-		/* Fall through. */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_F64:
 		if (src != dst_r) {
 			if (!(dst & SLJIT_MEM))

--- a/sljit_src/sljitNativeRISCV_common.c
+++ b/sljit_src/sljitNativeRISCV_common.c
@@ -4548,7 +4548,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 #if (defined SLJIT_CONFIG_RISCV_64 && SLJIT_CONFIG_RISCV_64)
 	case SLJIT_MOV32:
 		mem_flags = INT_DATA;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_S32:
 		if ((init_value & 0x800) != 0)
 			init_value ^= ~(sljit_sw)0xfff;

--- a/sljit_src/sljitNativeS390X.c
+++ b/sljit_src/sljitNativeS390X.c
@@ -168,7 +168,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 				return (cc0 | cc3);
 			return (cc0 | cc2);
 		}
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ATOMIC_STORED:
 	case SLJIT_F_EQUAL:
@@ -184,7 +184,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 				return (cc1 | cc2);
 			return (cc1 | cc3);
 		}
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_UNORDERED_OR_NOT_EQUAL:
 		return (cc1 | cc2 | cc3);
@@ -215,7 +215,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 	case SLJIT_NOT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_SUB)
 			return (cc2 | cc3);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_SIG_LESS_EQUAL:
 	case SLJIT_F_LESS_EQUAL:
@@ -225,7 +225,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 	case SLJIT_CARRY:
 		if (compiler->status_flags_state & SLJIT_CURRENT_FLAGS_SUB)
 			return (cc0 | cc1);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_SIG_GREATER:
 	case SLJIT_UNORDERED_OR_GREATER:
@@ -238,7 +238,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 	case SLJIT_OVERFLOW:
 		if (compiler->status_flags_state & SLJIT_SET_Z)
 			return (cc2 | cc3);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_UNORDERED:
 		return cc3;
@@ -246,7 +246,7 @@ static SLJIT_INLINE sljit_u8 get_cc(struct sljit_compiler *compiler, sljit_s32 t
 	case SLJIT_NOT_OVERFLOW:
 		if (compiler->status_flags_state & SLJIT_SET_Z)
 			return (cc0 | cc1);
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 
 	case SLJIT_ORDERED:
 		return (cc0 | cc1 | cc2);
@@ -2361,7 +2361,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op1(struct sljit_compiler *compile
 	case SLJIT_REV_U32:
 	case SLJIT_REV_S32:
 		op |= SLJIT_32;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_REV:
 	case SLJIT_REV_U16:
 	case SLJIT_REV_S16:
@@ -3810,7 +3810,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op_flags(struct sljit_compiler *co
 		break;
 	case SLJIT_MOV32:
 		op |= SLJIT_32;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV:
 		/* can write straight into destination */
 		loc_r = dst_r;
@@ -4593,7 +4593,7 @@ SLJIT_API_FUNC_ATTRIBUTE struct sljit_const* sljit_emit_const(struct sljit_compi
 
 	case SLJIT_MOV32:
 		is_32 = 1;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case SLJIT_MOV_S32:
 		PTR_FAIL_IF(push_inst(compiler, 0xc00100000000 /* lgfi */ | R36A(dst_r) | (sljit_ins)(init_value & 0xffffffff)));
 		break;

--- a/sljit_src/sljitNativeX86_common.c
+++ b/sljit_src/sljitNativeX86_common.c
@@ -4060,7 +4060,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_replicate(struct sljit_compil
 		else
 			FAIL_IF(emit_groupf(compiler, PSHUFLW_x_xm | EX86_PREF_F2 | EX86_SSE2, vreg, vreg, 0));
 		FAIL_IF(emit_byte(compiler, 0));
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	default:
 		if (use_vex)
 			FAIL_IF(emit_vex_instruction(compiler, PSHUFD_x_xm | EX86_PREF_66 | EX86_SSE2, vreg, 0, vreg, 0));
@@ -4634,7 +4634,7 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_simd_lane_replicate(struct sljit_c
 			return emit_vex_instruction(compiler, VPBROADCASTD_x_xm | EX86_PREF_66 | VEX_OP_0F38 | EX86_SSE2, vreg, 0, vreg, 0);
 
 		src = vreg;
-		/* fallthrough */
+		SLJIT_FALLTHROUGH; /* fallthrough */
 	case 2:
 		byte = U8(src_lane_index);
 		byte = U8(byte | (byte << 2));


### PR DESCRIPTION
This pull request is related to https://github.com/PCRE2Project/pcre2/pull/789 where we introduced a dedicated macro called PCRE2_FALLTHROUGH to annotate intentional fall through from a previous case label.

For our code we using clang with -Wimplicit-fallthrough and -Werror enabled which helped us identify a few odd places in our code base. Similar to PCRE2 in SLJIT those places have already been commented and I propose to use the corresponding compiler attribute (via a new macro called SLJIT_FALLTHROUGH for compatibility reasons) to make the compiler aware the fact that fallthrough is allowed at these places.