### PR TITLE
config: prevent aarch64_be from being misdetected

### DIFF
--- a/sljit_src/sljitConfig.h
+++ b/sljit_src/sljitConfig.h
@@ -133,7 +133,7 @@ extern "C" {
       nonzero value - FPU is present.
 */
 
-/* For further configurations, see the beginning of sljitConfigInternal.h */
+/* For further configurations, see sljitConfigCPU.h and sljitConfigInternal.h */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sljit_src/sljitConfigCPU.h
+++ b/sljit_src/sljitConfigCPU.h
@@ -185,4 +185,74 @@
 #define SLJIT_CONFIG_LOONGARCH 1
 #endif
 
+/*************************/
+/* Endianness detection. */
+/*************************/
+
+#if !defined(SLJIT_BIG_ENDIAN) && !defined(SLJIT_LITTLE_ENDIAN)
+
+#if defined(SLJIT_CONFIG_ARM) && SLJIT_CONFIG_ARM
+
+#ifdef __ARM_BIG_ENDIAN
+#define SLJIT_BIG_ENDIAN 1
+#else
+#define SLJIT_LITTLE_ENDIAN 1
+#endif
+
+#elif (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
+
+#ifdef __LITTLE_ENDIAN__
+#define SLJIT_LITTLE_ENDIAN 1
+#else
+#define SLJIT_BIG_ENDIAN 1
+#endif
+
+#elif (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
+
+#ifdef __MIPSEL__
+#define SLJIT_LITTLE_ENDIAN 1
+#else
+#define SLJIT_BIG_ENDIAN 1
+#endif
+
+#ifndef SLJIT_MIPS_REV
+
+/* Auto detecting mips revision. */
+#if (defined __mips_isa_rev) && (__mips_isa_rev >= 6)
+#define SLJIT_MIPS_REV 6
+#elif defined(__mips_isa_rev) && __mips_isa_rev >= 1
+#define SLJIT_MIPS_REV __mips_isa_rev
+#elif defined(__clang__) \
+	&& (defined(_MIPS_ARCH_OCTEON) || defined(_MIPS_ARCH_P5600))
+/* clang either forgets to define (clang-7) __mips_isa_rev at all
+ * or sets it to zero (clang-8,-9) for -march=octeon (MIPS64 R2+)
+ * and -march=p5600 (MIPS32 R5).
+ * It also sets the __mips macro to 64 or 32 for -mipsN when N <= 5
+ * (should be set to N exactly) so we cannot rely on this too.
+ */
+#define SLJIT_MIPS_REV 1
+#endif
+
+#endif /* !SLJIT_MIPS_REV */
+
+#elif (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X)
+
+#define SLJIT_BIG_ENDIAN 1
+
+#else
+
+#define SLJIT_LITTLE_ENDIAN 1
+
+#endif
+
+#endif /* !defined(SLJIT_BIG_ENDIAN) && !defined(SLJIT_LITTLE_ENDIAN) */
+
+#if (defined(SLJIT_CONFIG_ARM_64) && SLJIT_CONFIG_ARM_64) \
+	&& (defined(SLJIT_BIG_ENDIAN) && SLJIT_BIG_ENDIAN)
+
+#undef SLJIT_CONFIG_ARM_64
+#define SLJIT_CONFIG_UNSUPPORTED 1
+
+#endif
+
 #endif /* SLJIT_CONFIG_CPU_H_ */

--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -464,55 +464,6 @@ typedef double sljit_f64;
 /* Endianness detection. */
 /*************************/
 
-#if !defined(SLJIT_BIG_ENDIAN) && !defined(SLJIT_LITTLE_ENDIAN)
-
-/* These macros are mostly useful for the applications. */
-#if (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
-
-#ifdef __LITTLE_ENDIAN__
-#define SLJIT_LITTLE_ENDIAN 1
-#else
-#define SLJIT_BIG_ENDIAN 1
-#endif
-
-#elif (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
-
-#ifdef __MIPSEL__
-#define SLJIT_LITTLE_ENDIAN 1
-#else
-#define SLJIT_BIG_ENDIAN 1
-#endif
-
-#ifndef SLJIT_MIPS_REV
-
-/* Auto detecting mips revision. */
-#if (defined __mips_isa_rev) && (__mips_isa_rev >= 6)
-#define SLJIT_MIPS_REV 6
-#elif defined(__mips_isa_rev) && __mips_isa_rev >= 1
-#define SLJIT_MIPS_REV __mips_isa_rev
-#elif defined(__clang__) \
-	&& (defined(_MIPS_ARCH_OCTEON) || defined(_MIPS_ARCH_P5600))
-/* clang either forgets to define (clang-7) __mips_isa_rev at all
- * or sets it to zero (clang-8,-9) for -march=octeon (MIPS64 R2+)
- * and -march=p5600 (MIPS32 R5).
- * It also sets the __mips macro to 64 or 32 for -mipsN when N <= 5
- * (should be set to N exactly) so we cannot rely on this too.
- */
-#define SLJIT_MIPS_REV 1
-#endif
-
-#endif /* !SLJIT_MIPS_REV */
-
-#elif (defined SLJIT_CONFIG_S390X && SLJIT_CONFIG_S390X)
-
-#define SLJIT_BIG_ENDIAN 1
-
-#else
-#define SLJIT_LITTLE_ENDIAN 1
-#endif
-
-#endif /* !defined(SLJIT_BIG_ENDIAN) && !defined(SLJIT_LITTLE_ENDIAN) */
-
 /* Sanity check. */
 #if (defined SLJIT_BIG_ENDIAN && SLJIT_BIG_ENDIAN) && (defined SLJIT_LITTLE_ENDIAN && SLJIT_LITTLE_ENDIAN)
 #error "Exactly one endianness must be selected"


### PR DESCRIPTION
aarch64_be uses little endian instructions, and therefore the current generator will generate invalid instructions.

while it is possible to fix that, I am not sure how useful it would be as the architecture is fairly niche, so make sure that it will error out instead.