### PR TITLE
Fix TARGET_OS_IPHONE support

### DIFF
--- a/sljit_src/allocator_src/sljitExecAllocatorApple.c
+++ b/sljit_src/allocator_src/sljitExecAllocatorApple.c
@@ -109,6 +109,8 @@ static SLJIT_INLINE void apple_update_wx_flags(sljit_s32 enable_exec)
 #define SLJIT_MAP_JIT	(0)
 #endif
 
+#define SLJIT_UPDATE_WX_FLAGS(from, to, enable_exec)
+
 #endif /* TARGET_OS_OSX */
 
 static SLJIT_INLINE void* alloc_chunk(sljit_uw size)


### PR DESCRIPTION
TARGET_OS_IPHONE support was lost around #151 due to the missing definition of SLJIT_UPDATE_WX_FLAGS