### PR TITLE
Fix build & test failures on MIPS R6

### DIFF
--- a/sljit_src/sljitConfigInternal.h
+++ b/sljit_src/sljitConfigInternal.h
@@ -147,7 +147,7 @@ extern "C" {
 #endif
 
 /***********************************************************/
-/* Intel Control-flow Enforcement Technology (CET) spport. */
+/* Intel Control-flow Enforcement Technology (CET) support.*/
 /***********************************************************/
 
 #ifdef SLJIT_CONFIG_X86
@@ -423,9 +423,15 @@ typedef double sljit_f64;
 #define SLJIT_CONV_MIN_FLOAT SLJIT_CONV_RESULT_MIN_INT
 #define SLJIT_CONV_NAN_FLOAT SLJIT_CONV_RESULT_ZERO
 #elif (defined SLJIT_CONFIG_MIPS && SLJIT_CONFIG_MIPS)
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#define SLJIT_CONV_MAX_FLOAT SLJIT_CONV_RESULT_MAX_INT
+#define SLJIT_CONV_MIN_FLOAT SLJIT_CONV_RESULT_MIN_INT
+#define SLJIT_CONV_NAN_FLOAT SLJIT_CONV_RESULT_ZERO
+#else /* SLJIT_MIPS_REV < 6 */
 #define SLJIT_CONV_MAX_FLOAT SLJIT_CONV_RESULT_MAX_INT
 #define SLJIT_CONV_MIN_FLOAT SLJIT_CONV_RESULT_MAX_INT
 #define SLJIT_CONV_NAN_FLOAT SLJIT_CONV_RESULT_MAX_INT
+#endif /* SLJIT_MIPS_REV >= 6 */
 #elif (defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
 #define SLJIT_CONV_MAX_FLOAT SLJIT_CONV_RESULT_MAX_INT
 #define SLJIT_CONV_MIN_FLOAT SLJIT_CONV_RESULT_MIN_INT

--- a/sljit_src/sljitNativeMIPS_common.c
+++ b/sljit_src/sljitNativeMIPS_common.c
@@ -249,8 +249,13 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define LDL		(HI(26))
 #define LDR		(HI(27))
 #define LDC1		(HI(53))
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#define LL		(HI(31) | LO(54))
+#define LLD		(HI(31) | LO(55))
+#else /* SLJIT_MIPS_REV < 6 */
 #define LL		(HI(48))
 #define LLD		(HI(52))
+#endif /* SLJIT_MIPS_REV >= 6 */
 #define LUI		(HI(15))
 #define LW		(HI(35))
 #define LWL		(HI(34))
@@ -286,8 +291,13 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define ROTR		(HI(0) | (1 << 21) | LO(2))
 #define ROTRV		(HI(0) | (1 << 6) | LO(6))
 #endif /* SLJIT_MIPS_REV >= 2 */
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#define SC		(HI(31) | LO(38))
+#define SCD		(HI(31) | LO(39))
+#else /* SLJIT_MIPS_REV < 6 */
 #define SC		(HI(56))
 #define SCD		(HI(60))
+#endif /* SLJIT_MIPS_REV >= 6 */
 #define SD		(HI(63))
 #define SDL		(HI(44))
 #define SDR		(HI(45))
@@ -317,10 +327,11 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define XORI		(HI(14))
 
 #if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 1)
-#define CLZ		(HI(28) | LO(32))
 #if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
-#define DCLZ		(LO(18))
+#define CLZ		((1 << 6) | LO(16))
+#define DCLZ		((1 << 6) | LO(18))
 #else /* SLJIT_MIPS_REV < 6 */
+#define CLZ		(HI(28) | LO(32))
 #define DCLZ		(HI(28) | LO(36))
 #define MOVF		(HI(0) | (0 << 16) | LO(1))
 #define MOVF_S		(HI(17) | FMT_S | (0 << 16) | LO(17))
@@ -332,8 +343,13 @@ static const sljit_u8 freg_map[SLJIT_NUMBER_OF_FLOAT_REGISTERS + 4] = {
 #define MOVZ_S		(HI(17) | FMT_S | LO(18))
 #define MUL		(HI(28) | LO(2))
 #endif /* SLJIT_MIPS_REV >= 6 */
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+#define PREF		(HI(31) | LO(53))
+#define PREF_OFFSET(offset)	(((sljit_ins)(offset) & 0x1ff) << 7)
+#else /* SLJIT_MIPS_REV < 6 */
 #define PREF		(HI(51))
 #define PREFX		(HI(19) | LO(15))
+#endif /* SLJIT_MIPS_REV >= 6 */
 #if defined(SLJIT_MIPS_REV) && SLJIT_MIPS_REV >= 2
 #define SEB		(HI(31) | (16 << 6) | LO(32))
 #define SEH		(HI(31) | (24 << 6) | LO(32))
@@ -2118,8 +2134,8 @@ static SLJIT_INLINE sljit_s32 emit_single_op(struct sljit_compiler *compiler, sl
 		}
 
 #if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
-		FAIL_IF(push_inst(compiler, SELECT_OP(DMUL, MUL) | S(src1) | T(src2) | D(dst), DR(dst)));
 		FAIL_IF(push_inst(compiler, SELECT_OP(DMUH, MUH) | S(src1) | T(src2) | DA(EQUAL_FLAG), EQUAL_FLAG));
+		FAIL_IF(push_inst(compiler, SELECT_OP(DMUL, MUL) | S(src1) | T(src2) | D(dst), DR(dst)));
 #else /* SLJIT_MIPS_REV < 6 */
 		FAIL_IF(push_inst(compiler, SELECT_OP(DMULT, MULT) | S(src1) | T(src2), MOVABLE_INS));
 		FAIL_IF(push_inst(compiler, MFHI | DA(EQUAL_FLAG), EQUAL_FLAG));
@@ -2516,6 +2532,37 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_op0(struct sljit_compiler *compile
 static sljit_s32 emit_prefetch(struct sljit_compiler *compiler,
         sljit_s32 src, sljit_sw srcw)
 {
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+	sljit_s32 base = src & REG_MASK;
+	sljit_s32 offset_reg;
+
+	if (!(src & OFFS_REG_MASK)) {
+		if (srcw <= 0xff && srcw >= -0x100)
+			return push_inst(compiler, PREF | S(base) | PREF_OFFSET(srcw), MOVABLE_INS);
+
+		FAIL_IF(load_immediate(compiler, DR(TMP_REG1), srcw));
+
+		if (base != 0)
+			FAIL_IF(push_inst(compiler, ADDU_W | S(base) | T(TMP_REG1) | D(TMP_REG1), DR(TMP_REG1)));
+
+		return push_inst(compiler, PREF | S(TMP_REG1), MOVABLE_INS);
+	}
+
+	srcw &= 0x3;
+	offset_reg = OFFS_REG(src);
+
+	if (SLJIT_UNLIKELY(srcw != 0)) {
+		FAIL_IF(push_inst(compiler, SLL_W | T(offset_reg) | D(TMP_REG1) | SH_IMM(srcw), DR(TMP_REG1)));
+		offset_reg = TMP_REG1;
+	}
+
+	if (base != 0) {
+		FAIL_IF(push_inst(compiler, ADDU_W | S(base) | T(offset_reg) | D(TMP_REG1), DR(TMP_REG1)));
+		offset_reg = TMP_REG1;
+	}
+
+	return push_inst(compiler, PREF | S(offset_reg), MOVABLE_INS);
+#else /* SLJIT_MIPS_REV < 6 */
 	if (!(src & OFFS_REG_MASK)) {
 		if (srcw <= SIMM_MAX && srcw >= SIMM_MIN)
 			return push_inst(compiler, PREF | S(src & REG_MASK) | IMM(srcw), MOVABLE_INS);
@@ -2532,6 +2579,7 @@ static sljit_s32 emit_prefetch(struct sljit_compiler *compiler,
 	}
 
 	return push_inst(compiler, PREFX | S(src & REG_MASK) | T(OFFS_REG(src)), MOVABLE_INS);
+#endif /* SLJIT_MIPS_REV >= 6 */
 }
 #endif /* SLJIT_MIPS_REV >= 1 */
 
@@ -4270,8 +4318,6 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_mem(struct sljit_compiler *compile
 #endif /* SLJIT_MIPS_REV >= 6 */
 }
 
-#if !(defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
-
 SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fmem(struct sljit_compiler *compiler, sljit_s32 type,
 	sljit_s32 freg,
 	sljit_s32 mem, sljit_sw memw)
@@ -4279,6 +4325,9 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fmem(struct sljit_compiler *compil
 	CHECK_ERROR();
 	CHECK(check_sljit_emit_fmem(compiler, type, freg, mem, memw));
 
+#if (defined SLJIT_MIPS_REV && SLJIT_MIPS_REV >= 6)
+	return sljit_emit_fmem_unaligned(compiler, type, freg, mem, memw);
+#else /* !(SLJIT_MIPS_REV >= 6) */
 	FAIL_IF(update_mem_addr(compiler, &mem, &memw, SIMM_MAX - ((type & SLJIT_32) ? 3 : 7)));
 	SLJIT_ASSERT(FAST_IS_REG(mem) && mem != TMP_REG2);
 
@@ -4358,9 +4407,8 @@ SLJIT_API_FUNC_ATTRIBUTE sljit_s32 sljit_emit_fmem(struct sljit_compiler *compil
 	FAIL_IF(push_inst(compiler, NOP, UNMOVABLE_INS));
 #endif /* MIPS III */
 	return SLJIT_SUCCESS;
+#endif /* SLJIT_MIPS_REV >= 6 */
 }
-
-#endif /* !SLJIT_MIPS_REV || SLJIT_MIPS_REV < 6 */
 
 #undef IMM_16_SECOND
 #undef IMM_16_FIRST


### PR DESCRIPTION
The code did not even compile, so it's certain to be untested.
    
  - Fix some op encoding issues
  - Provide a new emit_prefetch for R6
  - Provide the missing sljit_emit_fmem on R6, which prevented linking and running the tests.

---------

I didn't write much of the code in this PR! I just let GPT run stuff with qemu and fix things on its own.

It _claims_ to know all the MIPS opcodes, and I also asked it to use gnu-as to write out binary data and disassemble it for each MIPS subarchitecture to verify its knowledge.

The tests didn't pass before; now, they do. I simply used a combination of your own `sljit_test -v` tests, and the PCRE2 ones as well.